### PR TITLE
Fix dist-build TLS inlining hang (🎯T16)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,13 +160,11 @@ jobs:
             sanitize: address,undefined
             make_cxx: 'CXX="clang++-18 -std=c++20 -stdlib=libc++"'
             packages: clang-18 libc++-18-dev libc++abi-18-dev gdb
-            use_source: true  # dist single-TU exhausts ARM64 runner resources
           - os: ubuntu-24.04-arm
             name: Linux arm64 TSan
             sanitize: thread
             make_cxx: 'CXX="clang++-18 -std=c++20 -stdlib=libc++"'
             packages: clang-18 libc++-18-dev libc++abi-18-dev gdb
-            use_source: true  # dist single-TU exhausts ARM64 runner resources
 
     steps:
       - uses: actions/checkout@v4
@@ -181,10 +179,10 @@ jobs:
           sudo apt-get install -y ${{ matrix.packages }}
           sudo sysctl -w kernel.core_pattern=core.%p
 
-      - name: Build and test (${{ matrix.use_source && 'source' || 'dist' }}, ${{ matrix.sanitize }})
+      - name: Build and test (dist, ${{ matrix.sanitize }})
         run: |
           ulimit -c unlimited
-          make ${{ matrix.use_source && 'test' || 'test-dist' }} SANITIZE=${{ matrix.sanitize }} ${{ matrix.make_cxx || '' }}
+          make test-dist SANITIZE=${{ matrix.sanitize }} ${{ matrix.make_cxx || '' }}
         env:
           # libc++abi on Linux frees std::logic_error strings with free()
           # instead of operator delete, triggering false positives under ASan.

--- a/dist/csp_globals.cpp
+++ b/dist/csp_globals.cpp
@@ -6,6 +6,17 @@
 
 #include <cstdlib>
 
+// Prevent the compiler from inlining TLS accessor functions into callers.
+// In single-TU (dist) builds, inlining lets the compiler cache the resolved
+// TLS address across jump_fcontext calls. After fiber migration to a
+// different OS thread, the cached address is stale — writes go to the
+// wrong thread's TLS slot.  See docs/tls-caching-bug.md.
+#ifdef _MSC_VER
+#define CSP_TLS_NOINLINE __declspec(noinline)
+#else
+#define CSP_TLS_NOINLINE __attribute__((noinline))
+#endif
+
 namespace csp {
 
     writer<std::exception_ptr> global_exception_handler = std::move(chan<std::exception_ptr>().w);
@@ -18,8 +29,8 @@ namespace csp {
 
         static thread_local Imp * g_imp = nullptr;
 
-        Imp* current_imp() { return g_imp; }
-        void set_current_imp(Imp* p) { g_imp = p; }
+        CSP_TLS_NOINLINE Imp* current_imp() { return g_imp; }
+        CSP_TLS_NOINLINE void set_current_imp(Imp* p) { g_imp = p; }
 
         static thread_local Processor * tl_proc_ = nullptr;
         static bool runtime_initialized_ = false;
@@ -47,7 +58,7 @@ namespace csp {
             runtime_initialized_ = true;
         }
 
-        Processor& current_p() {
+        CSP_TLS_NOINLINE Processor& current_p() {
             if (!tl_proc_) {
                 if (!runtime_initialized_) {
                     init_runtime(resolve_maxprocs());
@@ -59,11 +70,11 @@ namespace csp {
             return *tl_proc_;
         }
 
-        bool has_processor() {
+        CSP_TLS_NOINLINE bool has_processor() {
             return tl_proc_ != nullptr;
         }
 
-        void bind_processor(Processor * p) {
+        CSP_TLS_NOINLINE void bind_processor(Processor * p) {
             tl_proc_ = p;
             g_imp = &p->main;
 #if CSP_TSAN

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -269,6 +269,29 @@
 - **Achieved**: 2026-03-27
 - **Discovered**: 2026-03-09
 
+### 🎯T16 Dist-build test suite does not hang on CI
+- **Weight**: 2 (value 5 / cost 5)
+- **Acceptance**:
+  - `make test-dist` completes reliably on all CI platforms (no hangs)
+  - No ARM64 or x86_64 `use_source` workarounds needed in CI
+  - Root cause identified and fixed (timing race, static init order, or TLS layout)
+- **Status**: not started
+- **Discovered**: 2026-04-07
+- **Context**: The dist build amalgamates all source into a single TU (`csp.cpp`),
+  with `csp_globals.cpp` kept separate (see `docs/tls-caching-bug.md` for why).
+  The resulting test binary intermittently hangs on CI runners — observed on
+  ARM64 (TSan, ASan) and x86_64 (test). Source-built tests never hang.
+  Single-TU compilation can cause semantic changes beyond timing: the
+  TLS caching bug that motivated the two-file split is a known example.
+  Other candidates: static init order changes, different inlining causing
+  different lock/unlock interleaving, ODR-invisible differences in internal
+  linkage symbols. Constrained multi-tenant CI runners trigger it more
+  often but the root cause may not be a race at all — it could be a
+  deterministic semantic difference that only manifests as a hang.
+  Currently worked around by using source builds for ARM64 sanitizer jobs.
+  Needs a structured investigation (`docs/papers/` → enumerate actors →
+  hypothesise → compare source vs dist binary behaviour).
+
 ### 🎯T14 Dynamic scoping improvements
 - **Weight**: 0.5 (value 3 / cost 6)
 - **Status**: parked (2026-04-05)

--- a/src/csp_globals.cpp
+++ b/src/csp_globals.cpp
@@ -5,6 +5,17 @@
 
 #include <cstdlib>
 
+// Prevent the compiler from inlining TLS accessor functions into callers.
+// In single-TU (dist) builds, inlining lets the compiler cache the resolved
+// TLS address across jump_fcontext calls. After fiber migration to a
+// different OS thread, the cached address is stale — writes go to the
+// wrong thread's TLS slot.  See docs/tls-caching-bug.md.
+#ifdef _MSC_VER
+#define CSP_TLS_NOINLINE __declspec(noinline)
+#else
+#define CSP_TLS_NOINLINE __attribute__((noinline))
+#endif
+
 namespace csp {
 
     writer<std::exception_ptr> global_exception_handler = std::move(chan<std::exception_ptr>().w);
@@ -17,8 +28,8 @@ namespace csp {
 
         static thread_local Imp * g_imp = nullptr;
 
-        Imp* current_imp() { return g_imp; }
-        void set_current_imp(Imp* p) { g_imp = p; }
+        CSP_TLS_NOINLINE Imp* current_imp() { return g_imp; }
+        CSP_TLS_NOINLINE void set_current_imp(Imp* p) { g_imp = p; }
 
         static thread_local Processor * tl_proc_ = nullptr;
         static bool runtime_initialized_ = false;
@@ -46,7 +57,7 @@ namespace csp {
             runtime_initialized_ = true;
         }
 
-        Processor& current_p() {
+        CSP_TLS_NOINLINE Processor& current_p() {
             if (!tl_proc_) {
                 if (!runtime_initialized_) {
                     init_runtime(resolve_maxprocs());
@@ -58,11 +69,11 @@ namespace csp {
             return *tl_proc_;
         }
 
-        bool has_processor() {
+        CSP_TLS_NOINLINE bool has_processor() {
             return tl_proc_ != nullptr;
         }
 
-        void bind_processor(Processor * p) {
+        CSP_TLS_NOINLINE void bind_processor(Processor * p) {
             tl_proc_ = p;
             g_imp = &p->main;
 #if CSP_TSAN


### PR DESCRIPTION
## Summary

- **Root cause**: In single-TU (dist) builds, the compiler inlines TLS accessor functions (`current_imp()`, `current_p()`, etc.) and caches the resolved TLS address across `jump_fcontext` calls. After fiber migration to a different OS thread, the cached address is stale — writes go to the wrong thread's TLS slot, causing hangs.
- **Fix**: Mark all TLS accessor functions in `csp_globals.cpp` with `noinline`, forcing opaque function calls that re-resolve TLS on every access. Verified via symbol table: dist `csp.o` shows `current_imp`/`current_p` as undefined external calls.
- **CI restored**: Removed `use_source` workarounds for ARM64 sanitizer jobs — all jobs now run dist builds again.
- Added 🎯T16 target tracking the issue.

## Test plan
- [x] Source build: 668/668 pass
- [x] Dist build: 659/659 pass locally
- [x] Symbol table confirms TLS accessors are not inlined in dist
- [ ] CI: all 10 jobs green with dist builds restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)