### PR TITLE
Release v0.9.0

### DIFF
--- a/STABILITY.md
+++ b/STABILITY.md
@@ -5,7 +5,7 @@ backwards-incompatible changes to the public API require a new product fork
 (there is no v2.0). The pre-1.0 period exists to get the interaction surface
 right before making that commitment.
 
-Snapshot as of v0.8.0.
+Snapshot as of v0.9.0.
 
 ## Interaction surface catalogue
 
@@ -16,9 +16,9 @@ namespaces (`csp::internal`, `csp::detail`) are not part of the public API.
 
 | Symbol | Value | Stability |
 |--------|-------|-----------|
-| `CSP_VERSION` | `"0.8.0"` | Stable |
+| `CSP_VERSION` | `"0.9.0"` | Stable |
 | `CSP_VERSION_MAJOR` | `0` | Stable |
-| `CSP_VERSION_MINOR` | `8` | Stable |
+| `CSP_VERSION_MINOR` | `9` | Stable |
 | `CSP_VERSION_PATCH` | `0` | Stable |
 
 ### Core types
@@ -216,6 +216,30 @@ TLS 1.3 only via PicoTLS minicrypto backend. No built-in X.509 verification.
 | `tls::context::set_verify(verify_fn)` | set custom cert verification callback | Stable |
 | `tls::conn` | TLS connection (pImpl) | Stable |
 
+### HTTP (`csp::http`, `include/csp/http.h`)
+
+HTTP/1.1 server and client built on llhttp (vendored). Body is buffered
+(streaming deferred). Server bypasses `net::listen` internally — see the
+project's http-server notes for the rationale.
+
+| Symbol | Kind | Stability |
+|--------|------|-----------|
+| `http::method` | enum class | Fluid |
+| `http::method_name(method)` | function | Fluid |
+| `http::response` | struct (`status`, `headers`, `body`) | Fluid |
+| `http::request` | struct (method, url, version, headers, body, keep_alive, `respond` writer) | Fluid |
+| `http::request::header(name)` | case-insensitive header lookup | Fluid |
+| `http::request::content_length()` | convenience accessor | Fluid |
+| `http::endpoint` | struct (`requests`, `remote_addr`) | Fluid |
+| `http::serve_options` | struct (`listen`, `max_header_size`, `read_chunk_size`) | Fluid |
+| `http::server` | struct (`endpoints`, `port`, `local_addr`) | Fluid |
+| `http::serve(port, opts)` | server factory | Fluid |
+| `http::serve(addr, port, opts)` | server factory | Fluid |
+| `http::fetch_options` | struct (`read_chunk_size`) | Fluid |
+| `http::fetch(method, url, headers, body, opts)` | one-shot client call | Fluid |
+| `http::get(url, headers, opts)` | convenience wrapper | Fluid |
+| `http::post(url, body, headers, opts)` | convenience wrapper | Fluid |
+
 ### Byte reader (`include/csp/byte_reader.h`)
 
 | Symbol | Kind | Stability |
@@ -334,6 +358,12 @@ Items that must be addressed before 1.0:
 
 6. **Distribution packaging** — `dist/` ships three files but no install
    target, pkg-config, or CMake find-module. Users must manually integrate.
+
+7. **HTTP surface** — Server and client landed in v0.9.0 with buffered
+   bodies only. Streaming request and response bodies, HTTPS (HTTP over
+   `tls::conn`), and the server / client structure are all Fluid until
+   proven in use. Expect refinements around the `response` struct,
+   `serve_options`, and client ergonomics (connection reuse, redirects).
 
 ## Out of scope for 1.0
 

--- a/dist/csp.h
+++ b/dist/csp.h
@@ -7,9 +7,9 @@
 
 /* csp/csp.h */
 
-#define CSP_VERSION "0.8.0"
+#define CSP_VERSION "0.9.0"
 #define CSP_VERSION_MAJOR 0
-#define CSP_VERSION_MINOR 8
+#define CSP_VERSION_MINOR 9
 #define CSP_VERSION_PATCH 0
 
 

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -222,3 +222,20 @@ None.
   - CI ccache caching via `actions/cache` — high payoff, ~5–8 CPU-min/run, requires CI review
   - PCH for `test/testutil.h` — ~1–2s additional savings, medium risk (dep tracking)
   - Test tiering (`make fast` target) — 31.8s test runtime dominates `make` wall time
+
+## 2026-04-22 — /release v0.9.0
+
+- **Commit**: `pending`
+- **Outcome**: Released v0.9.0. New networking surface: HTTP/1.1 server
+  (`csp::http::serve`, 🎯T3.2) and HTTP/1.1 client
+  (`csp::http::fetch` / `get` / `post`, 🎯T3.6), both built on the
+  vendored llhttp parser (MIT, attributed in `NOTICES`). Fixed
+  dist-build TLS inlining hang (🎯T16) — all TLS accessors now carry
+  `CSP_TLS_NOINLINE`, keeping sanitizer-enabled dist CI stable. Internal:
+  ccache wired into Makefile, `docs/targets.yaml` migrated to
+  `docs/bullseye.yaml`, Homebrew tap opted out (CSP ships as source,
+  not binary). HTTP surface marked Fluid in `STABILITY.md` — streaming
+  bodies, HTTPS, connection reuse, and redirects are deferred.
+- **Known issue**: Linux arm64 ASan+UBSan CI job hung on the prior
+  `81674ef` run (9 of 10 jobs passed). Investigation launched in
+  parallel with this release.

--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#define CSP_VERSION "0.8.0"
+#define CSP_VERSION "0.9.0"
 #define CSP_VERSION_MAJOR 0
-#define CSP_VERSION_MINOR 8
+#define CSP_VERSION_MINOR 9
 #define CSP_VERSION_PATCH 0
 
 #include <csp/internal/log.h>


### PR DESCRIPTION
# v0.9.0

## Added

- **HTTP/1.1 server** (`csp::http::serve`) built on the vendored
  [llhttp](https://github.com/nodejs/llhttp) parser (MIT). Each
  accepted connection produces a `csp::http::endpoint` with a
  `reader<http::request>`; each request carries a per-request
  `writer<http::response>`. Keep-alive is handled automatically, and
  dropping the server's `endpoints` reader stops accepting. (🎯T3.2)
- **HTTP/1.1 client** (`csp::http::fetch`, with `get` / `post`
  convenience wrappers). One-shot request/response over `http://`
  URLs. HTTPS will arrive with the HTTP-over-TLS integration. (🎯T3.6)

Both additions are marked **Fluid** in `STABILITY.md` — streaming
bodies, HTTPS, connection reuse, and redirect handling are all still
open design questions.

## Fixed

- **Dist-build TLS inlining hang** (🎯T16). In the single-TU `dist/`
  build the compiler could cache TLS addresses across
  `jump_fcontext`, causing sanitizer-enabled CI jobs to hang. All TLS
  accessors now carry `CSP_TLS_NOINLINE`, restoring reliable test
  runs on sanitizer-enabled dist builds.

## Internal

- Vendored `llhttp` under `vendor/github.com/nodejs/llhttp/` with
  MIT attribution in `NOTICES`.
- CI now uses `ccache` for clang builds; `docs/targets.yaml` migrated
  to `docs/bullseye.yaml` for the bullseye MCP workflow.
- Homebrew tap disabled in `CLAUDE.md` — CSP is a source-distributed
  library, not a binary, so the tap workflow does not apply.

## Known issues

- **Linux arm64 ASan+UBSan** CI job hung on the previous
  `81674ef` run (not a code failure — the other 9 jobs passed). The
  regression is being investigated as a follow-up; development on
  other platforms and sanitizer configurations is unaffected.
