### PR TITLE
Rewrite v0.9.0 audit-log commit hash

### DIFF
--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -225,7 +225,7 @@ None.
 
 ## 2026-04-22 — /release v0.9.0
 
-- **Commit**: `pending`
+- **Commit**: `e630654`
 - **Outcome**: Released v0.9.0. New networking surface: HTTP/1.1 server
   (`csp::http::serve`, 🎯T3.2) and HTTP/1.1 client
   (`csp::http::fetch` / `get` / `post`, 🎯T3.6), both built on the


### PR DESCRIPTION
Replace the `pending` placeholder in the v0.9.0 audit-log entry with the merge commit hash `e630654` (from PR #27).

Docs-only; triggers no CI under `paths-ignore`.