### PR TITLE
Fix flaky Timeout-expiry test and bound CI job runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
   test:
     name: test (${{ matrix.name }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -135,6 +136,7 @@ jobs:
   sanitize:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/test/chanutil.test.cc
+++ b/test/chanutil.test.cc
@@ -1114,16 +1114,17 @@ TEST_CASE("ChanUtil---Timeout-no-expiry") {
 
 TEST_CASE("ChanUtil---Timeout-expiry") {
     using namespace std::chrono_literals;
+    fake_clock fc;
     RunStats stats;
 
-    csp::run([]{
-        using namespace std::chrono_literals;
+    csp::run([&]{
+        csp::local l{fc.binding()};
         auto to = timeout<int>(100ms).spawn();
 
         csp::spawn([w = std::move(to.w)]{
             using namespace std::chrono_literals;
             w << 1;
-            csp::sleep(200ms);
+            csp::sleep(200ms);  // Fake-clock quiescence advances past timeout.
             w << 2;  // Timeout already fired.
         });
 


### PR DESCRIPTION
Two small follow-ups to the v0.9.0 release cycle:

- **`test/chanutil.test.cc`** — `ChanUtil---Timeout-expiry` used real 100ms/200ms sleeps, which missed the deadline under macOS arm64 runner load on the v0.9.0 release PR (PR #27). Bind a `fake_clock` inside `csp::run` so quiescence drives deterministic time advancement — same pattern as the rest of the timer-sensitive tests.

- **`.github/workflows/ci.yml`** — Add `timeout-minutes: 30` to the `test` and `sanitize` jobs. Two separate 6h runner hangs on `ubuntu-24.04-arm` ASan/TSan jobs during the v0.9.0 cycle (#24, #27) — capping at 30min means flaky arm64 sanitizer runners fail fast instead of eating the full CI ceiling.

Verified locally: `make` passes 677/677.