### PR TITLE
Release v0.10.0

### DIFF
--- a/STABILITY.md
+++ b/STABILITY.md
@@ -5,7 +5,7 @@ backwards-incompatible changes to the public API require a new product fork
 (there is no v2.0). The pre-1.0 period exists to get the interaction surface
 right before making that commitment.
 
-Snapshot as of v0.9.0.
+Snapshot as of v0.10.0.
 
 ## Interaction surface catalogue
 
@@ -16,9 +16,9 @@ namespaces (`csp::internal`, `csp::detail`) are not part of the public API.
 
 | Symbol | Value | Stability |
 |--------|-------|-----------|
-| `CSP_VERSION` | `"0.9.0"` | Stable |
+| `CSP_VERSION` | `"0.10.0"` | Stable |
 | `CSP_VERSION_MAJOR` | `0` | Stable |
-| `CSP_VERSION_MINOR` | `9` | Stable |
+| `CSP_VERSION_MINOR` | `10` | Stable |
 | `CSP_VERSION_PATCH` | `0` | Stable |
 
 ### Core types
@@ -109,6 +109,20 @@ namespaces (`csp::internal`, `csp::detail`) are not part of the public API.
 | `prialt(Ops&&...) → int` | Stable |
 | `prialt(vector<chan_op<T>>&) → int` | Stable |
 | `prialt(vector<chan_op<T>>&, none_t) → int` | Stable |
+
+### In-band exception delivery
+
+`writer<T>::_throw(std::exception_ptr)` sends an exception in place of
+a value on the next rendezvous; the reader observes it as a thrown
+exception at its `r >> val` / `prialt(...)` call site, and the channel
+remains live and continues to carry further values or exceptions.
+Buffered channels carry exceptions in-order with values.  See
+docs/papers/03-two-phase-prialt.md §8 for the wire mechanism.
+
+| Symbol | Stability |
+|--------|-----------|
+| `writer<T>::_throw(std::exception_ptr) → chan_op<T>` | Stable |
+| `chan_op<T>::take_exception() → exception_ptr` (capture without rethrow) | Needs review |
 
 ### Globals
 

--- a/dist/csp.h
+++ b/dist/csp.h
@@ -7,9 +7,9 @@
 
 /* csp/csp.h */
 
-#define CSP_VERSION "0.9.0"
+#define CSP_VERSION "0.10.0"
 #define CSP_VERSION_MAJOR 0
-#define CSP_VERSION_MINOR 9
+#define CSP_VERSION_MINOR 10
 #define CSP_VERSION_PATCH 0
 
 

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -239,3 +239,23 @@ None.
 - **Known issue**: Linux arm64 ASan+UBSan CI job hung on the prior
   `81674ef` run (9 of 10 jobs passed). Investigation launched in
   parallel with this release.
+
+## 2026-04-25 — /release v0.10.0
+
+- **Commit**: `pending`
+- **Outcome**: Released v0.10.0. Headline change: in-band exception
+  delivery on channels (🎯T18). `writer<T>::_throw(exception_ptr)` sends
+  an exception in place of a value on the next rendezvous; the reader
+  rethrows at its `r >> val` / `prialt(...)` call site and the channel
+  stays live. Buffered channels carry exceptions in-order with values.
+  Wire mechanism: low-bit tag on `ChanOp::message`; channel scheduler
+  unchanged, only phase-2 typed dispatch branches on the tag. Paper 03
+  §8 added; `dist/AGENTS-CSP.md` updated. Also added `make bullseye`
+  standing-invariants hook for the convergence skill, moved
+  `bullseye.yaml` from `docs/` to repo root, and shipped the prior
+  flaky-Timeout-expiry test fix from PR #29. CSP remains source-
+  distributed (no Homebrew tap, no release binaries).
+- **Known issue**: `timeout-flushes-partial-frame` test in
+  `frame.test.cc` is timing-sensitive and may flake on overloaded CI
+  runners; tracked separately. 🎯T16 (Linux x86_64 ASan+UBSan dist
+  hang) remains open.

--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#define CSP_VERSION "0.9.0"
+#define CSP_VERSION "0.10.0"
 #define CSP_VERSION_MAJOR 0
-#define CSP_VERSION_MINOR 9
+#define CSP_VERSION_MINOR 10
 #define CSP_VERSION_PATCH 0
 
 #include <csp/internal/log.h>


### PR DESCRIPTION
## Summary

Release v0.10.0 — version bump, STABILITY.md update, audit-log entry.

Headline change: in-band exception delivery on channels (🎯T18, PR #31).
`writer<T>::_throw(exception_ptr)` sends an exception in place of a value
on the next rendezvous; the reader rethrows at its `r >> val` /
`prialt(...)` call site and the channel stays live. Buffered channels
carry exceptions in-order with values.

Wire mechanism: low-bit tag on `ChanOp::message`. Channel scheduler is
unchanged — only phase-2 typed dispatch branches on the tag. Paper 03 §8
covers the design.

## Changes in this PR

- `CSP_VERSION` macros bumped to `0.10.0` (header + dist).
- `STABILITY.md` snapshot bumped; new "In-band exception delivery"
  subsection documents `_throw` and `take_exception`.
- `docs/audit-log.md` entry appended (Commit: `pending` — will be
  rewritten in a follow-up PR after squash-merge per the audit-log
  convention).

## Known CI flakes (not regressions)

- `timeout-flushes-partial-frame` (`frame.test.cc:75`) is
  timing-sensitive and occasionally flakes on overloaded macOS dist
  runners. Pre-existing.
- 🎯T16 (Linux x86_64 ASan+UBSan dist build occasionally hangs) remains
  open. Pre-existing.

## Test plan

- [x] `make bullseye` green locally
- [x] `make CSP_INCLUDE=dist test-dist` green locally (667/667)
- [x] `dist/csp.h` matches `include/csp/csp.h` after `make dist`
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
