### PR TITLE
Implement 🎯T3.1: ergonomic I/O wrappers

### DIFF
--- a/dist/AGENTS-CSP.md
+++ b/dist/AGENTS-CSP.md
@@ -338,16 +338,19 @@ Uses kqueue reactor (macOS), epoll (Linux), IOCP (Windows).
 ```cpp
 namespace csp::io {
 
-// Opaque fd wrapper. No implicit int conversion.
-struct fd_t {
-    explicit fd_t(int raw_fd = -1);
-    int raw() const;          // access the underlying descriptor
-    bool valid() const;       // raw() >= 0
-    bool is_nonblock() const; // O_NONBLOCK is set
+// Opaque fd wrapper. No implicit int/SOCKET conversion.
+// All CSP-produced fds are already non-blocking.
+class fd_t {
+public:
+    constexpr fd_t();                           // default: invalid
+    constexpr explicit fd_t(socket_t raw_fd);   // wrap raw descriptor
+    socket_t raw() const;       // access underlying descriptor (use sparingly)
+    bool valid() const;         // fd != invalid
+    bool is_nonblock() const;   // O_NONBLOCK is set (assertion helper)
     explicit operator bool() const;  // same as valid()
-    // Comparison operators (==, !=, <, etc.)
-    // Move-only: copy is deleted.
+    // operator<=> and operator== defined (comparable, sortable)
 };
+constexpr fd_t invalid_fd{};    // sentinel for "no fd"
 
 // Layer 1: suspend until fd ready.
 void wait_readable(fd_t fd);
@@ -360,13 +363,18 @@ fd_t accept(fd_t listen_fd, sockaddr* addr, socklen_t* addrlen); // returned fd 
 int connect(fd_t fd, const sockaddr* addr, socklen_t addrlen); // 0=ok
 
 // Convenience: read until EOF.
-std::vector<uint8_t> read_all(fd_t fd);
+std::vector<uint8_t> read_all(fd_t fd, size_t chunk_size = 4096);
 
-// Convenience: write all bytes, throw on failure.
-void write_all(fd_t fd, std::span<const uint8_t> data);
+// Convenience: write all bytes, throw csp::error on failure.
+void write_all(fd_t fd, const std::vector<uint8_t>& data);
+void write_all(fd_t fd, const void* data, size_t len);
+
+// Convenience: split fd output into LF-delimited strings.
+// Composes byte_reader | split_lines. Returns reader<string>. Owns fd.
+reader<std::string> lines(fd_t fd, size_t chunk_size = 4096);
 
 // Utility.
-int set_nonblock(fd_t fd);
+int set_nonblock(fd_t fd);  // returns 0 on success, -1 on error
 
 // DNS (runs on blocking pool).
 // resolve_result { addrinfo_ptr info; int error; explicit operator bool(); const char* message(); }
@@ -381,8 +389,9 @@ namespace csp::file {
 // Read entire file into a vector (runs on blocking pool).
 std::vector<uint8_t> read(const std::string& path);
 
-// Write data to file (runs on blocking pool). Throws on failure.
-void write(const std::string& path, std::span<const uint8_t> data);
+// Write data to file (runs on blocking pool). Throws csp::error on failure.
+void write(const std::string& path, const std::vector<uint8_t>& data);
+void write(const std::string& path, const void* data, size_t len);
 }
 ```
 
@@ -396,7 +405,9 @@ auto r = csp::part::io::byte_reader(fd, 65536).spawn();   // custom size
 auto w = csp::part::io::byte_writer(fd).spawn();
 
 // lines: fd → reader<string> (composes byte_reader | split_lines).
-auto lr = csp::part::io::lines(fd).spawn();
+// Available as both csp::io::lines and csp::part::io::lines.
+auto lr = csp::io::lines(fd);              // csp::io namespace (preferred)
+auto lr = csp::part::io::lines(fd);       // same result
 
 // split_lines: byte stream → string stream (LF-delimited).
 auto lr = csp::part::io::split_lines.spawn(std::move(byte_reader));
@@ -738,7 +749,7 @@ All in `namespace csp::part` (included via `csp.h`).
 | `killswitch<T>()` | filter | Forward until keepalive dies |
 | `last<T>(n)` | filter | Buffer; emit last n on close |
 | `latch<T>()` | filter | Serve most recent value on demand |
-| `io::lines(fd)` | producer | fd → `reader<string>` via `byte_reader \| split_lines` |
+| `io::lines(fd)` | function | fd → `reader<string>` via `byte_reader \| split_lines`; also `csp::io::lines(fd)` |
 | `map<In,Out>(f)` | filter | Transform each element |
 | `merge<T>(readers...)` | producer | Non-deterministic merge |
 | `mux(reader<Ts>...)` | producer | Heterogeneous merge into `variant<Ts...>` |

--- a/dist/csp.cpp
+++ b/dist/csp.cpp
@@ -2264,6 +2264,10 @@ void write_all(fd_t fd, const void* data, size_t len) {
     }
 }
 
+csp::reader<std::string> lines(fd_t fd, size_t chunk_size) {
+    return csp::part::io::lines(fd, chunk_size);
+}
+
 } // namespace csp::io
 
 /* log.cc */

--- a/dist/csp.h
+++ b/dist/csp.h
@@ -2707,6 +2707,7 @@ void write(const std::string& path, const void* data, size_t len);
 /* csp/io.h */
 
 
+
 #ifdef _WIN32
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
@@ -2969,6 +2970,11 @@ struct resolve_result {
 // The fd must be non-blocking.
 void write_all(fd_t fd, const std::vector<uint8_t>& data);
 void write_all(fd_t fd, const void* data, size_t len);
+
+// Split fd output into newline-delimited strings. Composes
+// byte_reader | split_lines. Owns the fd and closes it on EOF.
+// The fd must be non-blocking.
+[[nodiscard]] csp::reader<std::string> lines(fd_t fd, size_t chunk_size = 4096);
 
 }
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -23,7 +23,8 @@ state.operation(args) ─┤guard├──➤ effects; result
 | Document | Header | Contents |
 |---|---|---|
 | [Timers](timers.md) | `csp.h` | `sleep`, `sleep_until`, `after`, `tick` |
-| [I/O](io.md) | `csp.h` | `wait_readable`, `wait_writable`, `read`, `write`, `accept`, `connect`, `resolve` (kqueue reactor) |
+| [I/O](io.md) | `csp.h` | `fd_t`, `wait_readable`, `wait_writable`, `read`, `write`, `accept`, `connect`, `resolve`, `read_all`, `write_all`, `lines`; `file::read`, `file::write` |
+| [Networking](net.md) | `csp.h` | `net::connection`, `net::listen`, `net::dial` (TCP) |
 | [Signals](signals.md) | `csp.h` | `signal::notify` (self-pipe trick, reactor-driven) |
 | [Blocking](blocking.md) | `csp.h` | `blocking(fn)` (offload to OS thread pool) |
 

--- a/docs/reference/io.md
+++ b/docs/reference/io.md
@@ -1,12 +1,12 @@
 # I/O Reference
 
 Non-blocking I/O primitives that integrate with the imp scheduler via
-a kqueue reactor. All functions live in `namespace csp::io`.
+a kqueue reactor. All functions live in `namespace csp::io` unless noted.
 
 Header: `#include "csp.h"`
 
 All I/O functions must be called from within an imp. The reactor is a
-singleton kqueue event loop running on a dedicated OS thread; when a
+singleton kqueue event loop running on a dedicated OS thread; when an
 imp calls an I/O function and the fd is not ready, the imp
 suspends cooperatively and is woken by the reactor when the fd becomes ready.
 
@@ -14,13 +14,68 @@ suspends cooperatively and is woken by the reactor when the fd becomes ready.
 
 ## Table of Contents
 
-1. [csp::io::wait_readable / csp::io::wait_writable](#cspiowait_readable-cspiowait_writable) -- suspend until fd is ready
-2. [csp::io::set_nonblock](#cspioset_nonblock) -- set fd to non-blocking mode
-3. [csp::io::read](#cspioread) -- non-blocking read
-4. [csp::io::write](#cspiowrite) -- non-blocking write
-5. [csp::io::accept](#cspioaccept) -- accept a connection
-6. [csp::io::connect](#cspioconnect) -- non-blocking connect
-7. [csp::io::resolve](#cspioresolve) -- async DNS resolution
+1. [csp::io::fd_t](#cspiofd_t) — opaque file descriptor wrapper
+2. [csp::io::wait_readable / csp::io::wait_writable](#cspiowait_readable-cspiowait_writable) — suspend until fd is ready
+3. [csp::io::set_nonblock](#cspioset_nonblock) — set fd to non-blocking mode
+4. [csp::io::read](#cspioread) — non-blocking read
+5. [csp::io::write](#cspiowrite) — non-blocking write
+6. [csp::io::accept](#cspioaccept) — accept a connection (returns fd_t)
+7. [csp::io::connect](#cspioconnect) — non-blocking connect
+8. [csp::io::resolve](#cspioresolve) — async DNS resolution
+9. [csp::io::read_all](#cspioread_all) — read all bytes until EOF
+10. [csp::io::write_all](#cspiowrite_all) — write all bytes
+11. [csp::io::lines](#cspiolines) — read newline-delimited strings
+12. [csp::file::read / csp::file::write](#cspfileread-cspfilewrite) — file I/O via blocking pool
+
+---
+
+## csp::io::fd_t
+
+Opaque file descriptor wrapper. No implicit conversion to the underlying
+integer type — all CSP-produced descriptors flow as `fd_t` values.
+
+### Declaration
+
+```cpp
+class fd_t {
+public:
+    constexpr fd_t();                           // default: invalid
+    constexpr explicit fd_t(socket_t fd);       // wrap raw descriptor
+
+    [[nodiscard]] constexpr socket_t raw() const;  // explicit raw access
+    [[nodiscard]] constexpr bool valid() const;
+    constexpr explicit operator bool() const;
+    [[nodiscard]] bool is_nonblock() const;     // query O_NONBLOCK flag
+
+    friend constexpr auto operator<=>(fd_t, fd_t) = default;
+    friend constexpr bool operator==(fd_t, fd_t) = default;
+};
+
+constexpr fd_t invalid_fd{};
+```
+
+### Description
+
+All CSP functions that produce file descriptors (`io::accept`,
+`net::listen`, `net::dial`) return an `fd_t` already set to non-blocking
+mode. `byte_reader` and `byte_writer` accept `fd_t` and assert (not
+silently fix) non-blocking status.
+
+Use `.raw()` only when calling platform APIs directly. For all CSP
+functions, pass `fd_t` directly.
+
+### Example
+
+```cpp
+#include "csp.h"
+
+// Wrap a raw fd (e.g. from open(2)):
+csp::io::fd_t fd{::open("/dev/null", O_RDONLY | O_NONBLOCK)};
+if (!fd) { /* error */ }
+
+// Pass to CSP functions:
+auto data = csp::io::read_all(fd);
+```
 
 ---
 
@@ -32,8 +87,8 @@ or writing.
 ### Signature
 
 ```cpp
-void wait_readable(int fd);
-void wait_writable(int fd);
+void wait_readable(fd_t fd);
+void wait_writable(fd_t fd);
 ```
 
 ### Description
@@ -44,6 +99,9 @@ imp. When the reactor detects that `fd` has data available (or has
 reached EOF or error), it wakes the imp. `wait_writable` does the same
 with `EVFILT_WRITE`.
 
+If a cancellation scope is active, the wait competes with the cancel
+signal in a `prialt`: whichever fires first wins.
+
 The higher-level wrappers (`read`, `write`, `accept`, `connect`) call these
 internally. Use them directly when building custom I/O protocols on raw file
 descriptors.
@@ -53,8 +111,10 @@ descriptors.
 ```
 wait_readable(fd) ─┤fd ready├──➤ return
 wait_readable(fd) ─┤fd not ready├─➤ suspend; reactor wakes imp when readable
+wait_readable(fd) ─┤cancel active, cancel fires first├─➤ throw canceled{}
 wait_writable(fd) ─┤fd ready├──➤ return
 wait_writable(fd) ─┤fd not ready├─➤ suspend; reactor wakes imp when writable
+wait_writable(fd) ─┤cancel active, cancel fires first├─➤ throw canceled{}
 ```
 
 ### Example
@@ -63,11 +123,12 @@ wait_writable(fd) ─┤fd not ready├─➤ suspend; reactor wakes imp when wr
 #include "csp.h"
 
 csp::spawn([] {
-    int fd = /* ... open a non-blocking fd ... */;
+    int raw = ::open("/tmp/fifo", O_RDONLY | O_NONBLOCK);
+    csp::io::fd_t fd{raw};
     csp::io::wait_readable(fd);
     // fd is now ready for reading
     char buf[1024];
-    ssize_t n = ::read(fd, buf, sizeof(buf));
+    ssize_t n = ::read(fd.raw(), buf, sizeof(buf));
 });
 csp::schedule();
 ```
@@ -81,15 +142,18 @@ Set a file descriptor to non-blocking mode.
 ### Signature
 
 ```cpp
-int set_nonblock(int fd);
+int set_nonblock(fd_t fd);
 ```
 
 ### Description
 
 Calls `fcntl` to add `O_NONBLOCK` to the file descriptor's flags. Returns 0
-on success, -1 on error (with `errno` set). This is a utility function -- not
-imp-specific -- but is typically the first thing called after creating
-a socket that will be used with the `csp::io` wrappers.
+on success, -1 on error (with `errno` set). This is a utility function — not
+imp-specific — but is typically the first thing called after wrapping a
+platform-created socket in an `fd_t`.
+
+CSP-produced `fd_t` values (from `io::accept`, `net::dial`) are already
+non-blocking — no need to call `set_nonblock` on them.
 
 ### Transition rules ([syntax](transition-rules.md))
 
@@ -101,8 +165,9 @@ set_nonblock(fd) ─┤error├───➤ return -1; errno set
 ### Example
 
 ```cpp
-int sock = socket(AF_INET, SOCK_STREAM, 0);
-csp::io::set_nonblock(sock);
+int raw = ::socket(AF_INET, SOCK_STREAM, 0);
+csp::io::fd_t fd{raw};
+csp::io::set_nonblock(fd);
 ```
 
 ---
@@ -114,7 +179,7 @@ Non-blocking read from a file descriptor.
 ### Signature
 
 ```cpp
-ssize_t read(int fd, void* buf, size_t len);
+[[nodiscard]] ssize_t read(fd_t fd, void* buf, size_t len);
 ```
 
 ### Description
@@ -125,7 +190,7 @@ imp suspends via `wait_readable` until data is available, then retries.
 Interrupted calls (`EINTR`) are retried automatically.
 
 Returns the number of bytes read on success, 0 on EOF, or -1 on error (with
-`errno` set). A successful call may return fewer than `len` bytes -- this is
+`errno` set). A successful call may return fewer than `len` bytes — this is
 normal for non-blocking reads.
 
 ### Transition rules ([syntax](transition-rules.md))
@@ -143,17 +208,13 @@ read(fd, buf, len) ─┤other error├─────➤ return -1; errno set
 ```cpp
 #include "csp.h"
 
-csp::spawn([] {
-    auto [w, r] = csp::chan<std::string>{};
-
-    csp::spawn([w = std::move(w)](int fd) {
-        char buf[4096];
-        for (;;) {
-            ssize_t n = csp::io::read(fd, buf, sizeof(buf));
-            if (n <= 0) break;
-            w << std::string(buf, static_cast<size_t>(n));
-        }
-    });
+csp::spawn([](csp::io::fd_t fd) {
+    char buf[4096];
+    for (;;) {
+        ssize_t n = csp::io::read(fd, buf, sizeof(buf));
+        if (n <= 0) break;
+        // process buf[0..n-1]
+    }
 });
 csp::schedule();
 ```
@@ -167,7 +228,7 @@ Non-blocking write to a file descriptor. Writes all bytes before returning.
 ### Signature
 
 ```cpp
-ssize_t write(int fd, const void* buf, size_t len);
+[[nodiscard]] ssize_t write(fd_t fd, const void* buf, size_t len);
 ```
 
 ### Description
@@ -196,8 +257,7 @@ write(fd, buf, len) ─┤other error├────➤ return -1; errno set
 ```cpp
 #include "csp.h"
 
-csp::spawn([] {
-    int fd = /* ... connected socket ... */;
+csp::spawn([](csp::io::fd_t fd) {
     const char* msg = "hello, world\n";
     ssize_t n = csp::io::write(fd, msg, strlen(msg));
     // n == strlen(msg) on success, -1 on error
@@ -214,7 +274,7 @@ Accept a connection on a listening socket.
 ### Signature
 
 ```cpp
-int accept(int listen_fd, struct sockaddr* addr, socklen_t* addrlen);
+[[nodiscard]] fd_t accept(fd_t listen_fd, struct sockaddr* addr, socklen_t* addrlen);
 ```
 
 ### Description
@@ -224,17 +284,16 @@ Accepts an incoming connection on `listen_fd`. If no connection is pending
 the reactor signals that a connection is ready. Interrupted calls (`EINTR`)
 are retried automatically.
 
-Returns the new socket fd on success, or -1 on error (with `errno` set). The
-caller is responsible for setting the returned fd to non-blocking mode and
-closing it when done.
+Returns a new `fd_t` already set to non-blocking mode on success, or
+`invalid_fd` on error. The caller is responsible for closing the returned fd.
 
 ### Transition rules ([syntax](transition-rules.md))
 
 ```
-accept(fd, addr, len) ─┤connection pending├─➤ return new_fd
+accept(fd, addr, len) ─┤connection pending├─➤ return new fd_t (non-blocking)
 accept(fd, addr, len) ─┤EAGAIN├─────────────➤ suspend until fd readable; retry
 accept(fd, addr, len) ─┤EINTR├──────────────➤ retry immediately
-accept(fd, addr, len) ─┤other error├────────➤ return -1; errno set
+accept(fd, addr, len) ─┤other error├────────➤ return invalid_fd; errno set
 ```
 
 ### Example
@@ -244,30 +303,24 @@ accept(fd, addr, len) ─┤other error├────────➤ return -1;
 #include <netinet/in.h>
 
 csp::spawn([] {
-    int listen_fd = socket(AF_INET, SOCK_STREAM, 0);
+    int raw = socket(AF_INET6, SOCK_STREAM, 0);
+    csp::io::fd_t listen_fd{raw};
     csp::io::set_nonblock(listen_fd);
+    // bind + listen omitted for brevity
 
-    struct sockaddr_in addr{};
-    addr.sin_family = AF_INET;
-    addr.sin_addr.s_addr = INADDR_ANY;
-    addr.sin_port = htons(8080);
-    bind(listen_fd, (struct sockaddr*)&addr, sizeof(addr));
-    listen(listen_fd, 128);
-
-    // Accept loop -- each connection handled in its own imp
     for (;;) {
-        int client_fd = csp::io::accept(listen_fd, nullptr, nullptr);
-        if (client_fd < 0) break;
-        csp::io::set_nonblock(client_fd);
+        csp::io::fd_t client = csp::io::accept(listen_fd, nullptr, nullptr);
+        if (!client) break;
 
-        csp::spawn([client_fd] {
+        // client is already non-blocking
+        csp::spawn([client] {
             char buf[1024];
-            ssize_t n = csp::io::read(client_fd, buf, sizeof(buf));
-            if (n > 0) csp::io::write(client_fd, buf, static_cast<size_t>(n));
-            close(client_fd);
+            ssize_t n = csp::io::read(client, buf, sizeof(buf));
+            if (n > 0) csp::io::write(client, buf, static_cast<size_t>(n));
+            csp::io::close(client);
         });
     }
-    close(listen_fd);
+    csp::io::close(listen_fd);
 });
 csp::schedule();
 ```
@@ -281,7 +334,7 @@ Initiate a non-blocking TCP connection.
 ### Signature
 
 ```cpp
-int connect(int fd, const struct sockaddr* addr, socklen_t addrlen);
+[[nodiscard]] int connect(fd_t fd, const struct sockaddr* addr, socklen_t addrlen);
 ```
 
 ### Description
@@ -290,8 +343,7 @@ Starts a connection to `addr` on a non-blocking socket `fd`. The fd must
 already be in non-blocking mode (via `set_nonblock`). If the kernel returns
 `EINPROGRESS` (the usual case for non-blocking connect), the imp
 suspends via `wait_writable` until the connection attempt completes. On
-resumption, `getsockopt(SO_ERROR)` is checked to determine whether the
-connection succeeded or failed.
+resumption, `getsockopt(SO_ERROR)` is checked to determine success.
 
 Returns 0 on success, or -1 on error (with `errno` set to the connection
 error).
@@ -301,7 +353,7 @@ error).
 ```
 connect(fd, addr, len) ─┤immediate success├──➤ return 0
 connect(fd, addr, len) ─┤EINPROGRESS├────────➤ suspend until fd writable;
-                                                check SO_ERROR; return 0 or -1
+                                               check SO_ERROR; return 0 or -1
 connect(fd, addr, len) ─┤other error├────────➤ return -1; errno set
 ```
 
@@ -312,7 +364,8 @@ connect(fd, addr, len) ─┤other error├────────➤ return -1
 #include <netinet/in.h>
 
 csp::spawn([] {
-    int fd = socket(AF_INET, SOCK_STREAM, 0);
+    int raw = socket(AF_INET, SOCK_STREAM, 0);
+    csp::io::fd_t fd{raw};
     csp::io::set_nonblock(fd);
 
     struct sockaddr_in addr{};
@@ -323,12 +376,9 @@ csp::spawn([] {
     if (csp::io::connect(fd, (struct sockaddr*)&addr, sizeof(addr)) == 0) {
         const char* msg = "GET / HTTP/1.0\r\n\r\n";
         csp::io::write(fd, msg, strlen(msg));
-
-        char buf[4096];
-        ssize_t n = csp::io::read(fd, buf, sizeof(buf));
-        // process response...
+        auto data = csp::io::read_all(fd);
     }
-    close(fd);
+    csp::io::close(fd);
 });
 csp::schedule();
 ```
@@ -349,9 +399,9 @@ struct resolve_result {
     const char* message() const;           // gai_strerror(error)
 };
 
-resolve_result resolve(const std::string& host,
-                       const std::string& service = {},
-                       const struct addrinfo* hints = nullptr);
+[[nodiscard]] resolve_result resolve(const std::string& host,
+                                     const std::string& service = {},
+                                     const struct addrinfo* hints = nullptr);
 ```
 
 ### Description
@@ -359,18 +409,12 @@ resolve_result resolve(const std::string& host,
 Resolves a hostname and/or service name to a list of socket addresses.
 Internally, `getaddrinfo` is offloaded to the blocking thread pool via
 `csp::blocking`, so the calling imp suspends cooperatively instead
-of blocking its processor. This is important because `getaddrinfo` is a
-blocking system call that can take an unpredictable amount of time (DNS
-lookups, `/etc/hosts` parsing, mDNS).
+of blocking its processor.
 
-On success, the returned `expected` holds an `addrinfo_ptr` (a `unique_ptr`
-with a custom deleter that calls `freeaddrinfo`). On failure, it holds a
-`resolve_error` with the `EAI_*` error code and a `message()` method for a
-human-readable description.
-
-The optional `hints` parameter controls the resolution behavior (address
-family, socket type, protocol, flags) -- same semantics as the `hints`
-argument to `getaddrinfo(3)`.
+On success, `result.info` holds an `addrinfo_ptr` (a `unique_ptr` with a
+custom deleter that calls `freeaddrinfo`). On failure, `result.error` holds
+the `EAI_*` error code and `result.message()` provides a human-readable
+description.
 
 ### Transition rules ([syntax](transition-rules.md))
 
@@ -379,15 +423,14 @@ resolve(host, svc, hints) ──────────➤ offload getaddrinfo 
                                       suspend calling imp;
                                       return resolve_result
 
-result.has_value()        ──────────➤ *result contains addrinfo linked list
-!result.has_value()       ──────────➤ result.error().message() describes failure
+bool(result)              ──────────➤ true: result.info contains addrinfo list
+!bool(result)             ──────────➤ result.message() describes failure
 ```
 
 ### Example
 
 ```cpp
 #include "csp.h"
-#include <netinet/in.h>
 
 csp::spawn([] {
     struct addrinfo hints{};
@@ -396,21 +439,167 @@ csp::spawn([] {
 
     auto result = csp::io::resolve("example.com", "80", &hints);
     if (!result) {
-        // result.error().message() for details
+        fprintf(stderr, "resolve failed: %s\n", result.message());
         return;
     }
 
-    // Connect using the first result
-    int fd = socket((*result)->ai_family,
-                    (*result)->ai_socktype,
-                    (*result)->ai_protocol);
+    auto* ai = result.info.get();
+    int raw = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
+    csp::io::fd_t fd{raw};
     csp::io::set_nonblock(fd);
+    csp::io::connect(fd, ai->ai_addr, static_cast<socklen_t>(ai->ai_addrlen));
+    // ...
+});
+csp::schedule();
+```
 
-    if (csp::io::connect(fd, (*result)->ai_addr,
-                         (*result)->ai_addrlen) == 0) {
-        // connected successfully
+---
+
+## csp::io::read_all
+
+Read all bytes from a file descriptor until EOF.
+
+### Signature
+
+```cpp
+[[nodiscard]] std::vector<uint8_t> read_all(fd_t fd, size_t chunk_size = 4096);
+```
+
+### Description
+
+Calls `csp::io::read` in a loop until EOF (return value 0) or error.
+Suspends cooperatively while waiting for data. Returns all bytes read as
+a contiguous vector.
+
+### Example
+
+```cpp
+#include "csp.h"
+
+csp::spawn([](csp::io::fd_t fd) {
+    auto data = csp::io::read_all(fd);
+    std::string s(data.begin(), data.end());
+});
+csp::schedule();
+```
+
+---
+
+## csp::io::write_all
+
+Write all bytes to a file descriptor.
+
+### Signature
+
+```cpp
+void write_all(fd_t fd, const std::vector<uint8_t>& data);
+void write_all(fd_t fd, const void* data, size_t len);
+```
+
+### Description
+
+Calls `csp::io::write` and throws `csp::error` if the write is
+incomplete (partial write or error). Suspends cooperatively while waiting
+for the fd to accept data.
+
+### Example
+
+```cpp
+#include "csp.h"
+
+csp::spawn([](csp::io::fd_t fd) {
+    std::string msg = "hello\n";
+    csp::io::write_all(fd, msg.data(), msg.size());
+});
+csp::schedule();
+```
+
+---
+
+## csp::io::lines
+
+Read newline-delimited strings from a file descriptor.
+
+### Signature
+
+```cpp
+[[nodiscard]] csp::reader<std::string> lines(fd_t fd, size_t chunk_size = 4096);
+```
+
+### Description
+
+Composes `byte_reader(fd) | split_lines` into a `reader<std::string>`.
+Each read from the returned reader yields one newline-delimited line
+(newline stripped). A partial trailing line (no trailing `\n`) is flushed
+when the fd reaches EOF.
+
+The fd must be non-blocking. `lines` owns the fd and closes it on EOF or
+when the reader is dropped.
+
+See also `part::io::lines` (identical; `csp::io::lines` forwards to it).
+
+### Example
+
+```cpp
+#include "csp.h"
+
+csp::spawn([](csp::io::fd_t fd) {
+    for (std::string line; (csp::io::lines(fd) >> line);) {
+        printf("%s\n", line.c_str());
     }
-    close(fd);
+});
+csp::schedule();
+```
+
+---
+
+## csp::file::read / csp::file::write
+
+Blocking file I/O, offloaded to the blocking thread pool.
+
+Header: `#include "csp.h"` (via `csp/file.h`)
+
+### Signature
+
+```cpp
+namespace csp::file {
+
+[[nodiscard]] std::vector<uint8_t> read(const std::string& path);
+
+void write(const std::string& path, const std::vector<uint8_t>& data);
+void write(const std::string& path, const void* data, size_t len);
+
+}
+```
+
+### Description
+
+`file::read` reads an entire file into memory in one shot.
+`file::write` creates or overwrites a file atomically (truncates on open).
+Both offload the blocking OS calls to the blocking thread pool via
+`csp::blocking`, so the calling imp suspends cooperatively.
+
+Both throw `csp::error` on failure (file not found, permission denied, etc.).
+
+These functions use `std::ifstream` / `std::ofstream` internally and are
+suitable for configuration files, small data files, and test fixtures.
+For large streaming files or fine-grained I/O, use `io::read` / `io::write`
+with an `fd_t` opened with `O_NONBLOCK`.
+
+### Example
+
+```cpp
+#include "csp.h"
+
+csp::spawn([] {
+    // Write then read a file.
+    std::string msg = "hello, file I/O";
+    std::vector<uint8_t> data(msg.begin(), msg.end());
+    csp::file::write("/tmp/demo.txt", data);
+
+    auto result = csp::file::read("/tmp/demo.txt");
+    std::string s(result.begin(), result.end());
+    assert(s == msg);
 });
 csp::schedule();
 ```

--- a/docs/reference/net.md
+++ b/docs/reference/net.md
@@ -1,0 +1,174 @@
+# TCP Networking Reference
+
+High-level TCP primitives built on top of `csp::io`. All types live in
+`namespace csp::net`.
+
+Header: `#include "csp.h"` (via `csp/net.h`)
+
+---
+
+## Table of Contents
+
+1. [csp::net::connection](#cspnetconnection) — connected socket with split I/O channels
+2. [csp::net::listen](#cspnetlisten) — TCP listener that produces connections
+3. [csp::net::dial](#cspnetdial) — connect to a remote host
+
+---
+
+## csp::net::connection
+
+A connected socket represented as a pair of channels.
+
+### Declaration
+
+```cpp
+struct connection {
+    io::fd_t fd;                            // underlying socket (non-blocking)
+    reader<std::vector<uint8_t>> input;     // bytes arriving from peer
+    writer<std::vector<uint8_t>> output;    // bytes to send to peer
+    std::string remote_addr;                // peer address ("host:port")
+};
+```
+
+### Description
+
+`connection` is a move-only struct. The `input` reader and `output` writer
+are backed by `byte_reader` / `byte_writer` imps spawned on the socket.
+Closing (dropping) either endpoint propagates to the other side:
+
+- Dropping `output` sends a TCP FIN to the peer (half-close write).
+- The `input` reader returns `false` once the peer closes or errors.
+- Dropping both closes the socket entirely.
+
+`fd` is the raw socket (already non-blocking). Prefer the channel API;
+use `fd.raw()` only for platform calls that require a socket descriptor.
+
+### Example
+
+```cpp
+auto conn = csp::net::dial("example.com", 80);
+
+std::string req = "GET / HTTP/1.0\r\nHost: example.com\r\n\r\n";
+std::vector<uint8_t> data(req.begin(), req.end());
+conn.output << data;
+
+// Signal EOF to peer:
+conn.output = {};
+
+// Read response:
+for (std::vector<uint8_t> chunk; conn.input >> chunk;) {
+    // process chunk
+}
+```
+
+---
+
+## csp::net::listen
+
+Create a TCP listener that produces `connection` values.
+
+### Signature
+
+```cpp
+struct listen_options {
+    int backlog  = 128;
+    bool reuse_addr = true;
+    bool dual_stack = true;   // IPv6+IPv4 dual-stack (IPV6_V6ONLY = 0)
+};
+
+struct listener {
+    reader<connection> connections;  // read to accept each connection
+    uint16_t port;                   // actual bound port (useful with port 0)
+    std::string local_addr;          // bound address string
+};
+
+listener listen(uint16_t port, listen_options opts = {});
+listener listen(const std::string& addr, uint16_t port, listen_options opts = {});
+```
+
+### Description
+
+`listen` binds to the given address/port and starts accepting connections
+in an internal imp. Each accepted connection is sent on
+`listener.connections`. The caller reads from that channel to obtain
+`connection` objects; each connection is ready for immediate I/O.
+
+Pass `port = 0` to let the OS assign an ephemeral port. The actual port is
+returned in `listener.port`.
+
+The accept loop stops when `listener.connections` is dropped (the reader
+is not kept alive). The underlying socket is closed automatically.
+
+DNS resolution for `addr` runs on the blocking pool (non-blocking for the
+calling imp).
+
+### Example
+
+```cpp
+#include "csp.h"
+
+// Echo server on an OS-assigned port.
+auto srv = csp::net::listen(0);
+printf("Listening on port %u\n", srv.port);
+
+csp::net::connection conn;
+while (srv.connections >> conn) {
+    csp::spawn([conn = std::move(conn)]() mutable {
+        std::vector<uint8_t> buf;
+        while (conn.input >> buf) {
+            conn.output << buf;
+        }
+    });
+}
+```
+
+---
+
+## csp::net::dial
+
+Connect to a remote TCP host.
+
+### Signature
+
+```cpp
+connection dial(const std::string& host, uint16_t port);
+connection dial(const std::string& host, const std::string& service);
+```
+
+### Description
+
+Resolves `host` via `csp::io::resolve` (DNS runs on the blocking pool),
+then attempts each resolved address in order until one succeeds. Returns
+a `connection` with a non-blocking socket and ready I/O channels.
+
+Throws `csp::error` if all addresses fail (connection refused, timeout,
+etc.). Throws `csp::canceled` if a cancellation scope fires during the
+attempt.
+
+### Example
+
+```cpp
+#include "csp.h"
+
+csp::spawn([] {
+    auto conn = csp::net::dial("example.com", 80);
+
+    std::string req = "GET / HTTP/1.0\r\nHost: example.com\r\n\r\n";
+    std::vector<uint8_t> data(req.begin(), req.end());
+    conn.output << data;
+    conn.output = {};   // half-close: signal EOF
+
+    for (std::vector<uint8_t> chunk; conn.input >> chunk;) {
+        fwrite(chunk.data(), 1, chunk.size(), stdout);
+    }
+});
+csp::schedule();
+```
+
+### Errors
+
+| Condition | Effect |
+|-----------|--------|
+| DNS resolution failure | throws `csp::error` |
+| All addresses refused / unreachable | throws `csp::error` |
+| Cancel scope fires | throws `csp::canceled` |

--- a/include/csp/io.h
+++ b/include/csp/io.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <csp/csp.h>
+
 #include <cassert>
 #include <compare>
 #include <cstddef>
@@ -269,5 +271,10 @@ struct resolve_result {
 // The fd must be non-blocking.
 void write_all(fd_t fd, const std::vector<uint8_t>& data);
 void write_all(fd_t fd, const void* data, size_t len);
+
+// Split fd output into newline-delimited strings. Composes
+// byte_reader | split_lines. Owns the fd and closes it on EOF.
+// The fd must be non-blocking.
+[[nodiscard]] csp::reader<std::string> lines(fd_t fd, size_t chunk_size = 4096);
 
 }

--- a/src/io.cc
+++ b/src/io.cc
@@ -1,6 +1,7 @@
 #include <csp/blocking.h>
 #include <csp/cancel.h>
 #include <csp/io.h>
+#include <csp/part/io.h>
 #include <csp/internal/signal.h>
 #include <csp/internal/reactor.h>
 
@@ -201,6 +202,10 @@ void write_all(fd_t fd, const void* data, size_t len) {
     if (n < 0 || static_cast<size_t>(n) != len) {
         throw csp::error("write_all: incomplete write");
     }
+}
+
+csp::reader<std::string> lines(fd_t fd, size_t chunk_size) {
+    return csp::part::io::lines(fd, chunk_size);
 }
 
 } // namespace csp::io

--- a/test/io.test.cc
+++ b/test/io.test.cc
@@ -617,7 +617,7 @@ TEST_CASE("IO---WriteAll") {
     csp::shutdown_runtime();
 }
 
-// --- io::lines (convenience) ---
+// --- io::lines (convenience via part::io) ---
 
 TEST_CASE("IO---Lines-convenience") {
     csp::shutdown_runtime();
@@ -648,6 +648,40 @@ TEST_CASE("IO---Lines-convenience") {
     CHECK("alpha" == result[0]);
     CHECK("beta" == result[1]);
     CHECK("gamma" == result[2]);
+    csp::shutdown_runtime();
+}
+
+// --- csp::io::lines (direct namespace convenience) ---
+
+TEST_CASE("IO---Lines-csp-io-namespace") {
+    csp::shutdown_runtime();
+    csp::set_maxprocs(2);
+
+    auto [rfd, wfd] = test_pipe();
+
+    csp::spawn([wfd] {
+        const char* data = "one\ntwo\nthree\n";
+        (void)csp::io::write(wfd, data, strlen(data));
+        test_close(wfd);
+    });
+
+    std::vector<std::string> result;
+    std::atomic<bool> done{false};
+
+    csp::spawn([&result, &done, rfd] {
+        auto lr = csp::io::lines(rfd);
+        for (std::string line; lr >> line;) {
+            result.push_back(std::move(line));
+        }
+        done.store(true, std::memory_order_relaxed);
+    });
+
+    csp::schedule();
+    CHECK(done.load());
+    REQUIRE(3 == result.size());
+    CHECK("one" == result[0]);
+    CHECK("two" == result[1]);
+    CHECK("three" == result[2]);
     csp::shutdown_runtime();
 }
 


### PR DESCRIPTION
- `csp::io::fd_t` was already in place; audit confirms all CSP-produced
  fds (io::accept, net::listen, net::dial) return fd_t already non-blocking.
- `byte_reader`/`byte_writer` already assert (not fix) non-blocking.
- Add `csp::io::lines(fd)` to the `csp::io` namespace as a thin wrapper
  over `part::io::lines`; declared in `io.h`, defined in `io.cc`.
  Requires adding `#include <csp/csp.h>` to `io.h` for `reader<string>`.
- Add test `IO---Lines-csp-io-namespace` verifying the new alias.
- Rewrite `docs/reference/io.md` with fd_t-based signatures throughout;
  add coverage of fd_t, read_all, write_all, lines, file::read/write.
- Create `docs/reference/net.md` covering connection, listen, dial.
- Update `docs/reference/README.md` to link net.md and expand io.md entry.
- Update `dist/AGENTS-CSP.md`: correct fd_t declaration, write_all/file::write
  signatures (std::span → actual overloads), lines classification, io::lines
  dual-namespace note.
- Regenerate `dist/csp.h` and `dist/csp.cpp` via `make dist`.

686/686 tests pass.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
