### PR TITLE
Add pull-based source abstraction — 🎯T17 Stage 1

### DIFF
--- a/dist/AGENTS-CSP.md
+++ b/dist/AGENTS-CSP.md
@@ -420,6 +420,65 @@ auto lr = csp::part::io::byte_reader(fd) | csp::part::io::split_lines;
 auto line_reader = lr.spawn();
 ```
 
+Pull-based source (🎯T17 Stage 1):
+```cpp
+namespace csp::io {
+
+// read_request: consumer asks for up to `value` bytes; source writes the
+// result (up to value bytes) into `reply`.
+using read_request = request<size_t, bytes>;
+
+// source: the consumer-facing handle (write end of a request channel).
+using source = writer<read_request>;
+
+// errno_error: thrown (via _throw) when io::read fails.
+class errno_error : public csp::error {
+public:
+    errno_error(const std::string& syscall, int err);
+    int err() const;
+};
+
+// fd_source: spawns an imp serving read_request values from a non-blocking fd.
+// The imp owns the fd and closes it on exit (EOF, error, or channel death).
+// Partial reads (< n bytes) are normal. Zero-byte requests throw
+// std::invalid_argument across the reply and exit.
+[[nodiscard]] source fd_source(fd_t fd);
+
+// Convenience: blocking call (uses writer::operator()).
+bytes source_read(source& s, size_t n);
+
+// Convenience: non-blocking — returns reply reader for use in prialt.
+reader<bytes> call_source(source& s, size_t n);
+
+} // namespace csp::io
+
+// Outcome model:
+// Success: reply >> chunk  → true; chunk contains 1..n bytes.
+// EOF:     reply >> chunk  → false (source imp exited; reply-writer dropped).
+// Error:   reply >> chunk  → throws errno_error (or other exception).
+
+// Sequential loop:
+auto s = csp::io::fd_source(fd);
+for (;;) {
+    auto reply = csp::io::call_source(s, 4096);
+    csp::bytes chunk;
+    if (!(reply >> chunk)) break;  // EOF
+    // use chunk
+}
+
+// prialt across two sources:
+auto r1 = csp::io::call_source(s1, 4096);
+auto r2 = csp::io::call_source(s2, 4096);
+csp::bytes b1, b2;
+switch (csp::prialt(r1 >> b1, r2 >> b2)) {
+case 0: /* b1 ready */ break;
+case 1: /* b2 ready */ break;
+}
+
+// Blocking sugar (writer::operator()):
+csp::bytes chunk = s(4096);   // throws on EOF/error
+```
+
 ## Networking
 
 ```cpp

--- a/dist/csp.h
+++ b/dist/csp.h
@@ -7884,6 +7884,140 @@ reader<int> notify(std::initializer_list<int> sigs);
 
 #endif // !_WIN32
 
+/* csp/source.h */
+
+// Pull-based sized-read abstraction (🎯T17 Stage 1).
+//
+// A source is a channel into which consumers submit read requests.
+// Each request carries the desired byte count and a one-shot reply
+// channel.  The source imp fills the request (up to N bytes) and writes
+// the result into the reply channel.  EOF, errors, and normal data each
+// travel on structurally distinct paths:
+//
+//   - Success:  the reply channel carries a bytes value.
+//   - EOF:      the source imp exits; the reply-writer drops; the
+//               consumer's reader<bytes> observes peer death (>> returns
+//               false).  Structural — no sentinel value needed.
+//   - Errors:   the source calls req.reply._throw(ep) before exiting;
+//               the consumer's >> rethrows at the call site.
+//
+// This file defines the type aliases and the fd_source factory
+// (Stage 1).  Higher layers (tls_source, http_body_source) are in
+// separate headers.
+
+
+#include <cerrno>
+#include <cstring>
+
+namespace csp::io {
+
+// --- Core type aliases ---
+
+// A single pull request: consumer asks for up to `value` bytes;
+// the source writes up to that many into the `reply` channel.
+using read_request = request<size_t, bytes>;
+
+// The consumer-facing handle.  A source is the *write* end of a
+// request channel — consumers write requests into it and read
+// replies from the one-shot reply channels embedded in each request.
+using source = writer<read_request>;
+
+// --- errno_error: carry a syscall name + errno across channels ---
+
+class errno_error : public csp::error {
+public:
+    errno_error(const std::string& syscall, int err)
+        : csp::error(syscall + ": " + std::strerror(err)), err_(err) {}
+
+    int err() const { return err_; }
+
+private:
+    int err_;
+};
+
+// --- fd_source: TCP / pipe source (Stage 1 concrete implementation) ---
+//
+// Spawns an imp that serves read_request values from a non-blocking fd.
+// Contract: up to N bytes per request, matching read(2) semantics.
+// Partial reads (m < N) are normal; the consumer decides whether to
+// re-request.
+//
+// Lifecycle:
+//   - EOF (io::read returns 0): imp exits without writing a reply.
+//     The reply-writer drops; the consumer's reader sees peer death.
+//   - Error (io::read returns < 0): imp throws errno_error across the
+//     current reply via _throw, then exits.  The consumer's >> rethrows.
+//   - Zero-byte request: imp throws std::invalid_argument and exits.
+//     (Almost always a caller bug; we surface it immediately.)
+//
+// The source owns the fd and closes it when the imp exits (normal,
+// EOF, or error).
+
+[[nodiscard]] inline source fd_source(fd_t fd) {
+    chan<read_request> ch;
+
+    spawn([req_r = std::move(ch.r), fd]() mutable {
+        internal::descr("fd_source");
+        assert(fd.is_nonblock() && "fd_source: fd must be non-blocking");
+
+        read_request req;
+        while (req_r >> req) {
+            if (req.value == 0) {
+                req.reply._throw(
+                    std::make_exception_ptr(
+                        std::invalid_argument("fd_source: zero-byte read request")));
+                csp::io::close(fd);
+                return;
+            }
+
+            bytes buf(req.value);
+            ssize_t n = csp::io::read(fd, buf.data(), buf.size());
+
+            if (n == 0) {
+                // EOF: exit without writing.  The reply-writer drops, and
+                // the consumer's reader<bytes> sees peer death.
+                csp::io::close(fd);
+                return;
+            }
+
+            if (n < 0) {
+                // Error: throw across the reply, then exit.
+                int err = errno;
+                req.reply._throw(
+                    std::make_exception_ptr(errno_error("read", err)));
+                csp::io::close(fd);
+                return;
+            }
+
+            buf.resize(static_cast<size_t>(n));
+            req.reply << std::move(buf);
+        }
+
+        // Request channel closed by consumer — clean shutdown.
+        csp::io::close(fd);
+    });
+
+    return std::move(ch.w);
+}
+
+// --- Convenience helpers for source consumers ---
+
+// Read exactly one request from a source and return the bytes.
+// Throws on error; throws csp::channel_closed on EOF.
+inline bytes source_read(source& s, size_t n) {
+    return s(n);
+}
+
+// Non-blocking form: returns a reader<bytes> for the response.
+// Use in prialt:
+//   auto reply = csp::io::call_source(s, 4096);
+//   prialt(reply >> buf, ~other);
+inline reader<bytes> call_source(source& s, size_t n) {
+    return call(s, n);
+}
+
+} // namespace csp::io
+
 /* csp/stack_analysis.h */
 
 

--- a/docs/reference/io.md
+++ b/docs/reference/io.md
@@ -26,6 +26,7 @@ suspends cooperatively and is woken by the reactor when the fd becomes ready.
 10. [csp::io::write_all](#cspiowrite_all) — write all bytes
 11. [csp::io::lines](#cspiolines) — read newline-delimited strings
 12. [csp::file::read / csp::file::write](#cspfileread-cspfilewrite) — file I/O via blocking pool
+13. [Pull-based source abstraction](#pull-based-source-abstraction) — consumer-controlled sized reads
 
 ---
 
@@ -603,3 +604,121 @@ csp::spawn([] {
 });
 csp::schedule();
 ```
+
+---
+
+## Pull-based source abstraction
+
+Header: `#include "csp/source.h"` (included by `"csp.h"`)
+
+A **source** inverts the push model: instead of the producer choosing
+chunk sizes, the consumer tells the source how many bytes it wants.  This
+is the CSP-native pull pattern built from `request<Req, Resp>`.
+
+### Type aliases
+
+```cpp
+namespace csp::io {
+
+// A single pull request: ask for up to `value` bytes; the source writes
+// up to that many into the `reply` one-shot channel.
+using read_request = request<size_t, bytes>;
+
+// The consumer-facing handle.  A source is the *write* end of a request
+// channel.  Consumers write requests into it and read replies from the
+// per-request reply channels.
+using source = writer<read_request>;
+
+} // namespace csp::io
+```
+
+### Outcome channels
+
+Three structurally distinct paths carry the three possible outcomes:
+
+| Outcome | Mechanism |
+|---------|-----------|
+| **Success** | The reply channel carries a `bytes` value (`<= n` bytes). |
+| **EOF** | The source imp exits; the reply-writer drops; `reply >> buf` returns `false`. |
+| **Error** | The source calls `req.reply._throw(ep)` before exiting; `reply >> buf` rethrows. |
+
+### fd_source
+
+```cpp
+[[nodiscard]] csp::io::source fd_source(csp::io::fd_t fd);
+```
+
+Spawns an imp that serves `read_request` values from a non-blocking fd.
+Partial reads (fewer bytes than requested) are normal and match `read(2)`
+semantics.  The imp owns the fd and closes it on exit.
+
+**Zero-byte requests** throw `std::invalid_argument` across the reply
+and exit — this is almost always a caller bug.
+
+### errno_error
+
+```cpp
+class csp::io::errno_error : public csp::error {
+public:
+    errno_error(const std::string& syscall, int err);
+    int err() const;
+};
+```
+
+Thrown (via `_throw`) when `io::read` returns a negative value.  Carries
+the syscall name and the `errno` at the time of failure.
+
+### Convenience helpers
+
+```cpp
+// Blocking call: send request, wait for reply, return bytes.
+// Throws errno_error on I/O error; throws channel_closed on EOF.
+bytes source_read(source& s, size_t n);
+
+// Non-blocking call: returns a reader<bytes> for use in prialt.
+reader<bytes> call_source(source& s, size_t n);
+```
+
+### Examples
+
+**Sequential reads:**
+
+```cpp
+#include "csp.h"
+
+auto s = csp::io::fd_source(rfd);
+
+csp::spawn([s = std::move(s)]() mutable {
+    for (;;) {
+        auto reply = csp::io::call_source(s, 4096);
+        csp::bytes chunk;
+        if (!(reply >> chunk)) break;  // EOF
+        // process chunk ...
+    }
+});
+```
+
+**prialt across two sources:**
+
+```cpp
+auto r1 = csp::io::call_source(s1, 4096);
+auto r2 = csp::io::call_source(s2, 4096);
+csp::bytes b1, b2;
+
+switch (csp::prialt(r1 >> b1, r2 >> b2)) {
+case 0: /* b1 ready */ break;
+case 1: /* b2 ready */ break;
+}
+```
+
+**writer::operator() sugar (blocking):**
+
+```cpp
+csp::bytes chunk = s(4096);  // blocks until reply; throws on EOF/error
+```
+
+### See also
+
+- Design paper: `docs/papers/19-pull-based-sources.md`
+- `request<Req, Resp>` and `call()` in [Channels reference](channels.md)
+- [🎯T17](../../bullseye.yaml) — full pull-based source convergence target

--- a/include/csp.h
+++ b/include/csp.h
@@ -102,6 +102,7 @@
 #include "csp/part/zip.h"
 #include "csp/ringbuffer.h"
 #include "csp/signal.h"
+#include "csp/source.h"
 #include "csp/stack_analysis.h"
 #include "csp/supervisor.h"
 #include "csp/timer.h"

--- a/include/csp/source.h
+++ b/include/csp/source.h
@@ -1,0 +1,137 @@
+#pragma once
+
+// Pull-based sized-read abstraction (🎯T17 Stage 1).
+//
+// A source is a channel into which consumers submit read requests.
+// Each request carries the desired byte count and a one-shot reply
+// channel.  The source imp fills the request (up to N bytes) and writes
+// the result into the reply channel.  EOF, errors, and normal data each
+// travel on structurally distinct paths:
+//
+//   - Success:  the reply channel carries a bytes value.
+//   - EOF:      the source imp exits; the reply-writer drops; the
+//               consumer's reader<bytes> observes peer death (>> returns
+//               false).  Structural — no sentinel value needed.
+//   - Errors:   the source calls req.reply._throw(ep) before exiting;
+//               the consumer's >> rethrows at the call site.
+//
+// This file defines the type aliases and the fd_source factory
+// (Stage 1).  Higher layers (tls_source, http_body_source) are in
+// separate headers.
+
+#include <csp/csp.h>
+#include <csp/io.h>
+
+#include <cerrno>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+
+namespace csp::io {
+
+// --- Core type aliases ---
+
+// A single pull request: consumer asks for up to `value` bytes;
+// the source writes up to that many into the `reply` channel.
+using read_request = request<size_t, bytes>;
+
+// The consumer-facing handle.  A source is the *write* end of a
+// request channel — consumers write requests into it and read
+// replies from the one-shot reply channels embedded in each request.
+using source = writer<read_request>;
+
+// --- errno_error: carry a syscall name + errno across channels ---
+
+class errno_error : public csp::error {
+public:
+    errno_error(const std::string& syscall, int err)
+        : csp::error(syscall + ": " + std::strerror(err)), err_(err) {}
+
+    int err() const { return err_; }
+
+private:
+    int err_;
+};
+
+// --- fd_source: TCP / pipe source (Stage 1 concrete implementation) ---
+//
+// Spawns an imp that serves read_request values from a non-blocking fd.
+// Contract: up to N bytes per request, matching read(2) semantics.
+// Partial reads (m < N) are normal; the consumer decides whether to
+// re-request.
+//
+// Lifecycle:
+//   - EOF (io::read returns 0): imp exits without writing a reply.
+//     The reply-writer drops; the consumer's reader sees peer death.
+//   - Error (io::read returns < 0): imp throws errno_error across the
+//     current reply via _throw, then exits.  The consumer's >> rethrows.
+//   - Zero-byte request: imp throws std::invalid_argument and exits.
+//     (Almost always a caller bug; we surface it immediately.)
+//
+// The source owns the fd and closes it when the imp exits (normal,
+// EOF, or error).
+
+[[nodiscard]] inline source fd_source(fd_t fd) {
+    chan<read_request> ch;
+
+    spawn([req_r = std::move(ch.r), fd]() mutable {
+        internal::descr("fd_source");
+        assert(fd.is_nonblock() && "fd_source: fd must be non-blocking");
+
+        read_request req;
+        while (req_r >> req) {
+            if (req.value == 0) {
+                req.reply._throw(
+                    std::make_exception_ptr(
+                        std::invalid_argument("fd_source: zero-byte read request")));
+                csp::io::close(fd);
+                return;
+            }
+
+            bytes buf(req.value);
+            ssize_t n = csp::io::read(fd, buf.data(), buf.size());
+
+            if (n == 0) {
+                // EOF: exit without writing.  The reply-writer drops, and
+                // the consumer's reader<bytes> sees peer death.
+                csp::io::close(fd);
+                return;
+            }
+
+            if (n < 0) {
+                // Error: throw across the reply, then exit.
+                int err = errno;
+                req.reply._throw(
+                    std::make_exception_ptr(errno_error("read", err)));
+                csp::io::close(fd);
+                return;
+            }
+
+            buf.resize(static_cast<size_t>(n));
+            req.reply << std::move(buf);
+        }
+
+        // Request channel closed by consumer — clean shutdown.
+        csp::io::close(fd);
+    });
+
+    return std::move(ch.w);
+}
+
+// --- Convenience helpers for source consumers ---
+
+// Read exactly one request from a source and return the bytes.
+// Throws on error; throws csp::channel_closed on EOF.
+inline bytes source_read(source& s, size_t n) {
+    return s(n);
+}
+
+// Non-blocking form: returns a reader<bytes> for the response.
+// Use in prialt:
+//   auto reply = csp::io::call_source(s, 4096);
+//   prialt(reply >> buf, ~other);
+inline reader<bytes> call_source(source& s, size_t n) {
+    return call(s, n);
+}
+
+} // namespace csp::io

--- a/test/source.test.cc
+++ b/test/source.test.cc
@@ -1,0 +1,331 @@
+#include "testutil.h"
+
+
+#include <atomic>
+#include <cstring>
+#include <stdexcept>
+
+#ifndef _WIN32
+#include <unistd.h>
+#endif
+
+using namespace csp;
+using namespace csp::io;
+
+// --- Platform pipe helpers (mirrored from io.test.cc) ---
+
+#ifdef _WIN32
+
+#include <winsock2.h>
+#include <ws2tcpip.h>
+
+inline std::pair<fd_t, fd_t> make_test_pipe() {
+    WSADATA wsa;
+    WSAStartup(MAKEWORD(2, 2), &wsa);
+    SOCKET listener = ::socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    REQUIRE(listener != INVALID_SOCKET);
+    struct sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = 0;
+    REQUIRE(::bind(listener, (sockaddr*)&addr, sizeof(addr)) == 0);
+    REQUIRE(::listen(listener, 1) == 0);
+    int alen = sizeof(addr);
+    REQUIRE(::getsockname(listener, (sockaddr*)&addr, &alen) == 0);
+    SOCKET ws = ::socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    REQUIRE(ws != INVALID_SOCKET);
+    REQUIRE(::connect(ws, (sockaddr*)&addr, sizeof(addr)) == 0);
+    SOCKET rs = ::accept(listener, nullptr, nullptr);
+    REQUIRE(rs != INVALID_SOCKET);
+    closesocket(listener);
+    return {fd_t(rs), fd_t(ws)};
+}
+
+inline void pipe_close(fd_t fd) { closesocket(fd.raw()); }
+inline ssize_t pipe_write(fd_t fd, const void* buf, size_t len) {
+    return ::send(fd.raw(), (const char*)buf, (int)len, 0);
+}
+
+#else
+
+inline std::pair<fd_t, fd_t> make_test_pipe() {
+    int pipefd[2];
+    REQUIRE_EQ(0, pipe(pipefd));
+    fd_t rfd(pipefd[0]);
+    fd_t wfd(pipefd[1]);
+    set_nonblock(rfd);
+    set_nonblock(wfd);
+    return {rfd, wfd};
+}
+
+inline void pipe_close(fd_t fd) { ::close(fd.raw()); }
+inline ssize_t pipe_write(fd_t fd, const void* buf, size_t len) {
+    return ::write(fd.raw(), buf, len);
+}
+
+#endif
+
+// --- Source tests ---
+
+// Basic: fd_source delivers bytes up to the requested count.
+TEST_CASE("Source---FdSource-basic-read") {
+    csp::shutdown_runtime();
+    csp::set_maxprocs(2);
+
+    auto [rfd, wfd] = make_test_pipe();
+    const char* msg = "Hello, source!";
+    size_t msglen = strlen(msg);
+
+    pipe_write(wfd, msg, msglen);
+    pipe_close(wfd);
+
+    bytes result;
+    std::atomic<bool> done{false};
+
+    auto s = fd_source(rfd);  // source owns rfd
+
+    csp::spawn([s = std::move(s), &result, &done]() mutable {
+        // Request all bytes in one shot.
+        auto reply = call_source(s, 4096);
+        bytes chunk;
+        if (reply >> chunk) {
+            result = std::move(chunk);
+        }
+        done.store(true, std::memory_order_relaxed);
+    });
+
+    csp::schedule();
+    CHECK(done.load());
+    std::string got(result.begin(), result.end());
+    CHECK(std::string(msg) == got);
+    csp::shutdown_runtime();
+}
+
+// EOF: fd_source exits cleanly when the fd reaches EOF.
+// The consumer's reader<bytes> observes peer death (>> returns false).
+TEST_CASE("Source---FdSource-EOF-via-death") {
+    csp::shutdown_runtime();
+    csp::set_maxprocs(2);
+
+    auto [rfd, wfd] = make_test_pipe();
+
+    // Write some data, then close writer to trigger EOF.
+    pipe_write(wfd, "AB", 2);
+    pipe_close(wfd);
+
+    bool got_data = false;
+    bool got_eof = false;
+    std::atomic<bool> done{false};
+
+    auto s = fd_source(rfd);
+
+    csp::spawn([s = std::move(s), &got_data, &got_eof, &done]() mutable {
+        // First request: should get "AB".
+        {
+            auto reply = call_source(s, 4096);
+            bytes chunk;
+            got_data = bool(reply >> chunk) && !chunk.empty();
+        }
+        // Second request: EOF — the imp exited; request channel is dead.
+        // The << on a dead writer returns false (or throws). Use try-approach:
+        // send a request and check if the reply comes back dead.
+        {
+            auto reply = call_source(s, 4096);
+            bytes chunk;
+            // This will observe either a dead request channel (the imp already
+            // exited) or a dead reply writer (EOF mid-request).
+            got_eof = !bool(reply >> chunk);
+        }
+        done.store(true, std::memory_order_relaxed);
+    });
+
+    csp::schedule();
+    CHECK(done.load());
+    CHECK(got_data);
+    CHECK(got_eof);
+    csp::shutdown_runtime();
+}
+
+// Partial read: fd_source returns less than requested — that is normal.
+TEST_CASE("Source---FdSource-partial-read") {
+    csp::shutdown_runtime();
+    csp::set_maxprocs(2);
+
+    auto [rfd, wfd] = make_test_pipe();
+    pipe_write(wfd, "XY", 2);
+    pipe_close(wfd);
+
+    std::atomic<size_t> got_bytes{0};
+    std::atomic<bool> done{false};
+
+    auto s = fd_source(rfd);
+
+    csp::spawn([s = std::move(s), &got_bytes, &done]() mutable {
+        // Request 4096, but only 2 bytes are available.
+        auto reply = call_source(s, 4096);
+        bytes chunk;
+        if (reply >> chunk) {
+            got_bytes.store(chunk.size(), std::memory_order_relaxed);
+        }
+        done.store(true, std::memory_order_relaxed);
+    });
+
+    csp::schedule();
+    CHECK(done.load());
+    CHECK(2 == got_bytes.load());
+    csp::shutdown_runtime();
+}
+
+// Zero-byte request: fd_source throws std::invalid_argument.
+TEST_CASE("Source---FdSource-zero-request-throws") {
+    csp::shutdown_runtime();
+    csp::set_maxprocs(2);
+
+    auto [rfd, wfd] = make_test_pipe();
+    pipe_close(wfd);  // wfd not needed
+
+    bool caught_invalid_arg = false;
+    std::atomic<bool> done{false};
+
+    auto s = fd_source(rfd);
+
+    csp::spawn([s = std::move(s), &caught_invalid_arg, &done]() mutable {
+        try {
+            auto reply = call_source(s, 0);  // zero-byte request
+            bytes chunk;
+            reply >> chunk;  // should throw std::invalid_argument
+        } catch (std::invalid_argument const&) {
+            caught_invalid_arg = true;
+        } catch (...) {
+            // unexpected exception — leave caught_invalid_arg = false
+        }
+        done.store(true, std::memory_order_relaxed);
+    });
+
+    csp::schedule();
+    CHECK(done.load());
+    CHECK(caught_invalid_arg);
+    csp::shutdown_runtime();
+}
+
+// prialt-able: two sources can be multiplexed with prialt.
+TEST_CASE("Source---FdSource-prialt-two-sources") {
+    csp::shutdown_runtime();
+    csp::set_maxprocs(4);
+
+    auto [rfd1, wfd1] = make_test_pipe();
+    auto [rfd2, wfd2] = make_test_pipe();
+
+    // Write to both pipes.
+    pipe_write(wfd1, "A", 1);
+    pipe_close(wfd1);
+    pipe_write(wfd2, "B", 1);
+    pipe_close(wfd2);
+
+    std::string collected;
+    std::atomic<bool> done{false};
+
+    auto s1 = fd_source(rfd1);
+    auto s2 = fd_source(rfd2);
+
+    csp::spawn([s1 = std::move(s1), s2 = std::move(s2),
+                &collected, &done]() mutable {
+        // Fire both requests simultaneously.
+        auto r1 = call_source(s1, 4096);
+        auto r2 = call_source(s2, 4096);
+
+        bytes b1, b2;
+
+        // Drain both with prialt.  Both replies are in flight so we can
+        // prialt on them together.
+        int got = 0;
+        while (got < 2) {
+            switch (csp::prialt(r1 >> b1, r2 >> b2)) {
+            case 0:
+                collected += std::string(b1.begin(), b1.end());
+                ++got;
+                break;
+            case 1:
+                collected += std::string(b2.begin(), b2.end());
+                ++got;
+                break;
+            default:
+                // A reply died (EOF before any data) — count it as done.
+                ++got;
+                break;
+            }
+        }
+        done.store(true, std::memory_order_relaxed);
+    });
+
+    csp::schedule();
+    CHECK(done.load());
+    // Both 'A' and 'B' should have arrived, in some order.
+    CHECK(2 == collected.size());
+    bool has_a = collected.find('A') != std::string::npos;
+    bool has_b = collected.find('B') != std::string::npos;
+    CHECK(has_a);
+    CHECK(has_b);
+    csp::shutdown_runtime();
+}
+
+// Multi-request: consumer loops over multiple requests on one source.
+TEST_CASE("Source---FdSource-multi-request-loop") {
+    csp::shutdown_runtime();
+    csp::set_maxprocs(2);
+
+    auto [rfd, wfd] = make_test_pipe();
+
+    // Write data in two batches.
+    pipe_write(wfd, "Hello", 5);
+    pipe_write(wfd, "World", 5);
+    pipe_close(wfd);
+
+    std::string accumulated;
+    std::atomic<bool> done{false};
+
+    auto s = fd_source(rfd);
+
+    csp::spawn([s = std::move(s), &accumulated, &done]() mutable {
+        for (;;) {
+            auto reply = call_source(s, 5);
+            bytes chunk;
+            if (!(reply >> chunk)) break;  // EOF
+            accumulated += std::string(chunk.begin(), chunk.end());
+        }
+        done.store(true, std::memory_order_relaxed);
+    });
+
+    csp::schedule();
+    CHECK(done.load());
+    // The kernel may combine writes; we just need all 10 bytes.
+    CHECK(10 == accumulated.size());
+    csp::shutdown_runtime();
+}
+
+// writer::operator() sugar: s(n) blocks until the reply arrives.
+TEST_CASE("Source---FdSource-operator()-sugar") {
+    csp::shutdown_runtime();
+    csp::set_maxprocs(2);
+
+    auto [rfd, wfd] = make_test_pipe();
+    pipe_write(wfd, "CSP", 3);
+    pipe_close(wfd);
+
+    bytes result;
+    std::atomic<bool> done{false};
+
+    auto s = fd_source(rfd);
+
+    csp::spawn([s = std::move(s), &result, &done]() mutable {
+        result = s(3);  // writer::operator() sugar for request/response
+        done.store(true, std::memory_order_relaxed);
+    });
+
+    csp::schedule();
+    CHECK(done.load());
+    std::string got(result.begin(), result.end());
+    // Might be fewer than 3 if partial; just check non-empty.
+    CHECK(!got.empty());
+    csp::shutdown_runtime();
+}


### PR DESCRIPTION
Introduces `csp::io::source` (an alias for `writer<request<size_t, bytes>>`)
and `csp::io::fd_source(fd)` as the first concrete implementation.  The
abstraction inverts the push model: consumers control byte counts, and the
syscall-level pull property is preserved all the way up the channel graph.

- `include/csp/source.h`: `read_request`, `source`, `errno_error`, `fd_source`,
  `source_read`, `call_source`.  Header-only; included by `csp.h`.
- `test/source.test.cc`: 7 tests covering basic reads, EOF-via-death, partial
  reads, zero-byte error delivery, prialt across two sources, multi-request
  loops, and `writer::operator()` sugar.
- `docs/reference/io.md`: Pull-based source reference section added.
- `dist/AGENTS-CSP.md`: Source API block added under I/O section.

All 692 tests pass.  Stages 2–5 (net::connection migration, http::fetch
streaming, http::serve bypass removal, TLS source) are deferred.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
