### PR TITLE
Release prep for v0.12.0

### DIFF
--- a/NOTICES
+++ b/NOTICES
@@ -136,3 +136,108 @@ nanobench
   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
   SOFTWARE.
+
+================================================================================
+
+llhttp
+  Copyright Fedor Indutny, 2018
+  https://github.com/nodejs/llhttp
+
+  MIT License
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+
+================================================================================
+
+nghttp2
+  Copyright (c) 2012, 2014, 2015, 2016 Tatsuhiro Tsujikawa
+  Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors
+  https://github.com/nghttp2/nghttp2
+
+  MIT License
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+
+================================================================================
+
+wslay
+  Copyright (c) 2011, 2012, 2015 Tatsuhiro Tsujikawa
+  https://github.com/tatsuhiro-t/wslay
+
+  MIT License
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+
+================================================================================
+
+nghttp3
+  Copyright (c) 2019 nghttp3 contributors
+  https://github.com/ngtcp2/nghttp3
+
+  MIT License
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -5,7 +5,7 @@ backwards-incompatible changes to the public API require a new product fork
 (there is no v2.0). The pre-1.0 period exists to get the interaction surface
 right before making that commitment.
 
-Snapshot as of v0.11.0.
+Snapshot as of v0.12.0.
 
 ## Interaction surface catalogue
 
@@ -16,9 +16,9 @@ namespaces (`csp::internal`, `csp::detail`) are not part of the public API.
 
 | Symbol | Value | Stability |
 |--------|-------|-----------|
-| `CSP_VERSION` | `"0.11.0"` | Stable |
+| `CSP_VERSION` | `"0.12.0"` | Stable |
 | `CSP_VERSION_MAJOR` | `0` | Stable |
-| `CSP_VERSION_MINOR` | `11` | Stable |
+| `CSP_VERSION_MINOR` | `12` | Stable |
 | `CSP_VERSION_PATCH` | `0` | Stable |
 
 ### Core types
@@ -109,6 +109,7 @@ namespaces (`csp::internal`, `csp::detail`) are not part of the public API.
 | `prialt(Ops&&...) → int` | Stable |
 | `prialt(vector<chan_op<T>>&) → int` | Stable |
 | `prialt(vector<chan_op<T>>&, none_t) → int` | Stable |
+| `closer<EP>` — vulture-only endpoint wrapper (CTAD, `operator~`, `operator bool`, `endpoint()`) | Stable |
 
 ### In-band exception delivery
 
@@ -198,13 +199,13 @@ docs/papers/03-two-phase-prialt.md §8 for the wire mechanism.
 
 | Symbol | Kind | Stability |
 |--------|------|-----------|
-| `dynamic<T>` | class template | Stable |
+| `dynamic<T>` | class template (main()-safe reads) | Stable |
 | `dynamic_binding` | deferred binding | Stable |
-| `local` | RAII binding scope | Stable |
-| `imp_local<T>` | class template | Stable |
+| `local` | RAII binding scope (throws `csp::error` outside an imp) | Stable |
+| `imp_local<T>` | class template (main()-safe reads; write throws outside an imp) | Stable |
 | `context_key` | unique key type | Stable |
-| `context` | HAMT root handle | Stable |
-| `context_scope` | RAII installer | Stable |
+| `context` | HAMT root handle (`current()` returns empty outside an imp) | Stable |
+| `context_scope` | RAII installer (throws `csp::error` outside an imp) | Stable |
 
 ### Unix signals (`csp::signal`)
 
@@ -453,11 +454,11 @@ Items that must be addressed before 1.0:
     drafted, stubs throw). Implementation depends on QUIC transport
     (T3.8) which is not yet started in master.
 
-11. **Windows portability** — v0.11.0 introduces the arena stack
-    allocator (T3.3) which uses `__builtin_trap()` and
-    `[[gnu::always_inline]]` in the suspend-point overflow check. Both
-    are GCC/Clang extensions that don't compile under MSVC. Windows is
-    a known-broken platform in v0.11.0; fix planned for v0.12.0.
+11. **Windows portability** — v0.12.0 makes the arena overflow check
+    portable (`__debugbreak()` on MSVC, `__builtin_trap()` elsewhere).
+    `[[gnu::always_inline]]` produces a recoverable warning, not an
+    error, on MSVC. Windows CI compiles cleanly; ws/http3 test suites
+    are excluded pending CMake wiring of wslay / nghttp3 / ngtcp2.
 
 ## Out of scope for 1.0
 

--- a/dist/csp.h
+++ b/dist/csp.h
@@ -7,9 +7,9 @@
 
 /* csp/csp.h */
 
-#define CSP_VERSION "0.11.0"
+#define CSP_VERSION "0.12.0"
 #define CSP_VERSION_MAJOR 0
-#define CSP_VERSION_MINOR 11
+#define CSP_VERSION_MINOR 12
 #define CSP_VERSION_PATCH 0
 
 

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -297,3 +297,20 @@ None.
   hit a stream-channel reader-move bug under handshake completion
   and was excluded from this release; both targets remain in the
   bullseye frontier for a clean restart.
+
+## 2026-04-29 — /release v0.12.0
+
+- **Commit**: `pending`
+- **Outcome**: Released v0.12.0 (source-only, no binaries). Closes
+  🎯T4 (API safety gaps) including 🎯T4.1 `closer<EP>` (vulture-only
+  spawn-handle wrapper, docs in `docs/reference/multiplexing.md`) and
+  🎯T4.2 main()-safe dynamic-scope APIs (`csp::local` /
+  `imp_local::operator=` / `context_scope` throw `csp::error` outside
+  any imp; `dynamic<T>` / `imp_local<T>` reads degrade to defaults).
+  Windows portability fix: `__builtin_trap()` → `__debugbreak()` on
+  MSVC; CMake test list now excludes ws/http3 pending wslay/nghttp3
+  CMake wiring. NOTICES updated for llhttp, nghttp2, wslay, nghttp3.
+  Bullseye sweep retired six already-shipped targets (🎯T3.2, 🎯T3.5,
+  🎯T3.6, 🎯T3.7, 🎯T3.9, 🎯T13). One PR since v0.11.0: #42. CI green
+  on all platforms (macOS arm64, Linux x86_64/arm64, ASan/UBSan, TSan,
+  TLA+, Windows x86_64).

--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#define CSP_VERSION "0.11.0"
+#define CSP_VERSION "0.12.0"
 #define CSP_VERSION_MAJOR 0
-#define CSP_VERSION_MINOR 11
+#define CSP_VERSION_MINOR 12
 #define CSP_VERSION_PATCH 0
 
 #include <csp/internal/log.h>


### PR DESCRIPTION
## Summary

Release v0.12.0 (source-only library, no binaries).

### Changes since v0.11.0

**Closes 🎯T4 — API safety gaps closed**
- 🎯T4.1 `closer<EP>` — vulture-only endpoint wrapper for spawn handles. CTAD, `operator~`, `operator bool`, `endpoint()`. Public-API docs added to `docs/reference/multiplexing.md` and `dist/AGENTS-CSP.md`. Existing 5 tests pass.
- 🎯T4.2 main()-safe dynamic-scope APIs — `csp::local`, `imp_local::operator=`, `context_scope` now throw `csp::error` with a clear message naming the API and pointing to `csp::run` / `csp::spawn` when called outside any imp. `dynamic<T>` / `imp_local<T>` reads degrade to defaults. `context::current()` returns empty. 7 new tests on a foreign std::thread.

**Windows portability**
- Replace `__builtin_trap()` with `__debugbreak()` on MSVC in the arena-stack overflow check (was blocking Windows CI since v0.11.0).
- Exclude `ws.test.cc` and `http3.test.cc` from Windows CMake builds pending wslay / nghttp3 / ngtcp2 wiring (matches existing pattern for nghttp2).

**Housekeeping**
- NOTICES: add MIT licence text for llhttp, nghttp2, wslay, nghttp3 — these were added in PRs #22, #38, and #39 without attribution updates.
- Bullseye sweep: retired six already-shipped targets that had drifted in `bullseye.yaml` (🎯T3.2 HTTP/1.1, 🎯T3.5 WebSocket, 🎯T3.6 HTTP client, 🎯T3.7 HTTP/2, 🎯T3.9 HTTP/3, 🎯T13 per-worker wake) — all verified by inspecting headers, source files, and passing test suites.
- STABILITY.md: snapshot v0.12.0; added `closer<EP>`; annotated dynamic-scope APIs with main()-safe behaviour; replaced the v0.11.0 Windows-broken gap with the v0.12.0 portability-fix note.

### Test plan
- [x] make: 723/723 pass (was 716; +7 new MainContext tests, –6 retired targets impl-side: none)
- [x] make test-dist: 689/689 pass
- [x] dist regenerated (`make dist`)
- [x] md-link check passes
- [x] CI green on master after merge of #42 (pre-existing red from v0.11.0 batch resolved by Windows fix in this cycle)

### Two-PR flow
This is the **release prep PR**. After squash-merge, a small follow-up PR will rewrite the `Commit: pending` placeholder in `docs/audit-log.md` to the real merge-commit hash, then the tag goes on the resulting master commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
