### PR TITLE
Fill v0.12.0 audit-log commit hash

### DIFF
--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -300,7 +300,7 @@ None.
 
 ## 2026-04-29 — /release v0.12.0
 
-- **Commit**: `pending`
+- **Commit**: `b1cb77f`
 - **Outcome**: Released v0.12.0 (source-only, no binaries). Closes
   🎯T4 (API safety gaps) including 🎯T4.1 `closer<EP>` (vulture-only
   spawn-handle wrapper, docs in `docs/reference/multiplexing.md`) and


### PR DESCRIPTION
Replaces `pending` placeholder in docs/audit-log.md with the squash-merge SHA `b1cb77f` from #43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)