### PR TITLE
🎯T7.5 Task scheduler example with DAG, timeout, and cancellation

### DIFF
--- a/examples/task_scheduler.cc
+++ b/examples/task_scheduler.cc
@@ -1,147 +1,358 @@
-// task_scheduler.cc — Priority task scheduler with worker pool
+// task_scheduler.cc — Priority task scheduler with DAG dependencies, timeouts,
+//                     worker pool, progress reporting, and Ctrl-C cancellation.
 //
-// Demonstrates: request/response (request<Req, Resp>, call, operator()),
-// worker pool pattern, progress reporting over channels, and the
-// channels-as-interfaces pattern (endpoint bundles).
+// Demonstrates:
+//   - Priority queue: dispatcher maintains a max-heap keyed by priority;
+//     jobs only enter the ready-queue once all their deps complete.
+//   - DAG dependency resolution: dep_tracker unblocks dependents when each
+//     job completes, without spawning per-job imps.
+//   - Per-job timeout: each worker runs the job under cancellation(timeout),
+//     catching csp::timed_out separately from csp::canceled (Ctrl-C).
+//   - Progress channel: every status transition posts to a dashboard imp.
+//   - Structured cancellation: SIGINT/SIGTERM → top-level cancel scope fires →
+//     workers catch csp::canceled, emit "cancelled" status, drain, then exit.
 //
-// Architecture:
-//   - Dispatcher imp: accepts submit requests, manages priority queue
-//   - Worker pool: N worker imps pull tasks and report completion
-//   - Progress reporter: prints status updates as tasks complete
-//   - Client: submits tasks via operator()
+// Demo DAG (10 jobs):
+//
+//   fetch-config (pri 10, 80ms)
+//   fetch-schema (pri 9, 120ms)
+//   └─ validate  (pri 8, 60ms)   deps: fetch-config, fetch-schema
+//   compile-a    (pri 7, 100ms)
+//   compile-b    (pri 7, 90ms)
+//   └─ link      (pri 6, 70ms)   deps: validate, compile-a, compile-b
+//   test-unit    (pri 5, 80ms)   deps: link
+//   test-integ   (pri 5, 250ms)  deps: link  timeout=200ms → timed_out
+//   package      (pri 4, 60ms)   deps: test-unit, test-integ
+//   deploy       (pri 3, 90ms)   deps: package
+//
+// Run: build/normal/examples/task_scheduler
+// Ctrl-C mid-run to see graceful cancellation.
 
 #include "csp.h"
 
+#include <chrono>
+#include <csignal>
 #include <cstdio>
+#include <map>
+#include <memory>
 #include <queue>
+#include <set>
 #include <string>
 #include <vector>
 
 using namespace csp;
+using namespace std::chrono_literals;
 
-// --- Task types ---
+// ---------------------------------------------------------------------------
+// Data types
+// ---------------------------------------------------------------------------
 
-struct Task {
+enum class Status { queued, ready, running, done, failed, timed_out, cancelled };
+
+static const char* status_name(Status s) {
+    switch (s) {
+        case Status::queued:    return "queued   ";
+        case Status::ready:     return "ready    ";
+        case Status::running:   return "running  ";
+        case Status::done:      return "done     ";
+        case Status::failed:    return "failed   ";
+        case Status::timed_out: return "timed_out";
+        case Status::cancelled: return "cancelled";
+    }
+    return "?";
+}
+
+struct Job {
     int id;
     std::string name;
-    int priority;       // higher = more urgent
-    int work_ms;        // simulated work duration
+    int priority;                              // higher = more urgent
+    std::vector<int> deps;                     // IDs that must complete first
+    std::chrono::milliseconds work;            // simulated work duration
+    std::chrono::milliseconds timeout;         // per-job deadline (0 = no limit)
 };
 
-struct TaskResult {
+struct ProgressEvent {
     int id;
-    std::string message;
+    std::string name;
+    Status status;
+    std::string detail;   // e.g. "worker 2" or "timed out after 200ms"
 };
 
-using SubmitReq = request<Task, int>;  // returns assigned task ID
+// ---------------------------------------------------------------------------
+// Scheduler internals
+// ---------------------------------------------------------------------------
 
-// --- Scheduler endpoint bundle ---
-// This is the "channels as interfaces" pattern: the scheduler's public
-// surface is a struct of typed endpoints, not a set of methods.
+// dep_tracker: tracks which jobs are still blocking each pending job.
+struct dep_tracker {
+    std::map<int, std::set<int>> pending;  // job_id → set of outstanding dep ids
 
-struct SchedulerEndpoints {
-    writer<SubmitReq> submit;         // send tasks here
-    reader<TaskResult> completions;   // receive completion events here
-};
+    void add(int job_id, std::vector<int> const& deps) {
+        if (deps.empty()) return;
+        pending[job_id] = std::set<int>(deps.begin(), deps.end());
+    }
 
-// Priority comparator: higher priority first.
-struct TaskCmp {
-    bool operator()(const Task& a, const Task& b) const {
-        return a.priority < b.priority;
+    // Record dep_id as complete; returns list of newly unblocked jobs.
+    std::vector<int> complete(int dep_id) {
+        std::vector<int> unblocked;
+        for (auto it = pending.begin(); it != pending.end(); ) {
+            it->second.erase(dep_id);
+            if (it->second.empty()) {
+                unblocked.push_back(it->first);
+                it = pending.erase(it);
+            } else {
+                ++it;
+            }
+        }
+        return unblocked;
+    }
+
+    // Record dep_id as failed; returns direct dependents (for cascade).
+    // Unlike complete(), a single failed dep dooms the waiting job.
+    std::vector<int> cancel(int dep_id) {
+        std::vector<int> doomed;
+        for (auto it = pending.begin(); it != pending.end(); ) {
+            if (it->second.count(dep_id)) {
+                doomed.push_back(it->first);
+                it = pending.erase(it);
+            } else {
+                ++it;
+            }
+        }
+        return doomed;
     }
 };
 
-static SchedulerEndpoints start_scheduler(int num_workers) {
-    chan<SubmitReq> submit_ch;
-    chan<Task> work_ch(16);           // buffered: decouple dispatch from workers
-    chan<TaskResult> completions_ch;
+// ---------------------------------------------------------------------------
+// Scheduler
+// ---------------------------------------------------------------------------
 
-    // Dispatcher: accepts submissions, assigns IDs, priority-sorts, dispatches.
-    spawn([submit_r = std::move(submit_ch.r),
-           work_w = std::move(work_ch.w)] {
-        std::priority_queue<Task, std::vector<Task>, TaskCmp> queue;
-        int next_id = 1;
+struct SchedulerHandle {
+    writer<Job> submit;             // caller submits jobs here
+    reader<ProgressEvent> progress; // dashboard reads events here
+};
 
-        SubmitReq req;
-        while (submit_r >> req) {
-            int id = next_id++;
-            req.value.id = id;
-            queue.push(std::move(req.value));
-            req.reply << id;
+// Completion notification from worker to dispatcher.
+// id > 0: job succeeded; id < 0: job failed/timed_out (abs(id) is the job ID).
+// Positive IDs unblock dependents; negative IDs cascade failure downward.
+struct Completion { int id; bool success; };
 
-            // Dispatch all queued tasks in priority order.
-            while (!queue.empty()) {
-                work_w << queue.top();
-                queue.pop();
+static SchedulerHandle start_scheduler(int num_workers) {
+    chan<Job> submit_ch;
+    chan<Job> ready_ch(32);                // buffered ready queue
+    chan<ProgressEvent> progress_ch(64);   // buffered progress feed
+    chan<Completion> done_ch(64);          // workers notify dispatcher
+
+    // --- Dispatcher imp ---
+    // Receives submitted jobs. Jobs with no deps immediately enter the
+    // priority queue. Others wait in dep_tracker until deps complete.
+    // On failure, cascade: mark stuck dependents as failed immediately.
+    spawn([sub_r   = std::move(submit_ch.r),
+           ready_w = std::move(ready_ch.w),
+           done_r  = std::move(done_ch.r),
+           prog_w  = progress_ch.w.copy()] () mutable {
+        auto cmp = [](Job const& a, Job const& b){ return a.priority < b.priority; };
+        std::priority_queue<Job, std::vector<Job>, decltype(cmp)> pq(cmp);
+        std::map<int, Job> staged;
+        dep_tracker deps;
+
+        auto dispatch_ready = [&] {
+            while (!pq.empty()) {
+                prog_w << ProgressEvent{pq.top().id, pq.top().name, Status::ready, ""};
+                if (!(ready_w << pq.top())) return;  // workers gone
+                pq.pop();
             }
+        };
+
+        // Cascade failure: mark all dependents as failed and recurse.
+        std::function<void(int)> cascade_failure = [&](int failed_id) {
+            for (int uid : deps.cancel(failed_id)) {
+                prog_w << ProgressEvent{uid, staged.at(uid).name,
+                                        Status::failed, "dep failed"};
+                cascade_failure(uid);
+                staged.erase(uid);
+            }
+        };
+
+        bool sub_alive = true;
+        Job job;
+        Completion comp;
+
+        while (sub_alive || !staged.empty()) {
+            int which;
+            if (sub_alive) {
+                which = alt(sub_r >> job, done_r >> comp);
+            } else {
+                // No more submissions; only wait for completions.
+                if (!(done_r >> comp)) break;
+                which = 1;
+            }
+
+            if (which == 0) {
+                prog_w << ProgressEvent{job.id, job.name, Status::queued, ""};
+                if (job.deps.empty()) {
+                    pq.push(job);
+                } else {
+                    deps.add(job.id, job.deps);
+                    staged[job.id] = job;
+                }
+                dispatch_ready();
+            } else if (which == 1) {
+                if (comp.success) {
+                    for (int uid : deps.complete(comp.id)) {
+                        pq.push(std::move(staged.at(uid)));
+                        staged.erase(uid);
+                    }
+                    dispatch_ready();
+                } else {
+                    // Job failed/timed_out: cascade failure to all stuck dependents.
+                    cascade_failure(comp.id);
+                }
+            } else if (which == ~0) {
+                // submit endpoint closed; keep waiting for completions.
+                sub_alive = false;
+            }
+            // ~1 = done_r closed: workers gone; exit loop.
         }
-        // submit_r died (all clients disconnected) → close work_ch
-        // by dropping work_w, which tells workers to exit.
     });
 
-    // Worker pool: each worker pulls tasks, simulates work, reports results.
-    for (int i = 0; i < num_workers; ++i) {
-        spawn([i, r = work_ch.r.copy(), w = completions_ch.w.copy()] {
-            Task task;
-            while (r >> task) {
-                sleep(std::chrono::milliseconds(task.work_ms));
-                char msg[128];
-                snprintf(msg, sizeof(msg), "completed by worker %d", i);
-                w << TaskResult{task.id, msg};
+    // --- Worker pool ---
+    for (int w = 0; w < num_workers; ++w) {
+        spawn([w, r = ready_ch.r.copy(),
+               done_w = done_ch.w.copy(),
+               prog_w = progress_ch.w.copy()] () mutable {
+            Job job;
+            while (r >> job) {
+                prog_w << ProgressEvent{job.id, job.name, Status::running,
+                                        "worker " + std::to_string(w)};
+                Status final_status = Status::done;
+                std::string detail = "worker " + std::to_string(w);
+                try {
+                    // Apply per-job timeout if specified; otherwise inherit
+                    // the parent cancel scope (top-level Ctrl-C).
+                    if (job.timeout.count() > 0) {
+                        auto tg = cancellation(job.timeout);
+                        sleep(job.work);
+                    } else {
+                        sleep(job.work);
+                    }
+                } catch (timed_out const&) {
+                    final_status = Status::timed_out;
+                    detail = "after " + std::to_string(job.timeout.count()) + "ms";
+                } catch (canceled const&) {
+                    final_status = Status::cancelled;
+                    detail = "Ctrl-C";
+                } catch (std::exception const& e) {
+                    final_status = Status::failed;
+                    detail = e.what();
+                }
+                prog_w << ProgressEvent{job.id, job.name, final_status, detail};
+                // Notify dispatcher with success/failure so it can unblock or
+                // cascade-fail dependents accordingly.
+                done_w << Completion{job.id, final_status == Status::done};
             }
         });
     }
 
     // Release shared endpoints — workers hold their own copies.
-    work_ch.r = {};
-    completions_ch.w = {};
+    ready_ch.r = {};
+    done_ch.w = {};
 
-    return {std::move(submit_ch.w), std::move(completions_ch.r)};
+    return {std::move(submit_ch.w), std::move(progress_ch.r)};
 }
+
+// ---------------------------------------------------------------------------
+// Dashboard
+// ---------------------------------------------------------------------------
+
+static void run_dashboard(reader<ProgressEvent> prog) {
+    spawn([r = std::move(prog)] {
+        ProgressEvent ev;
+        while (r >> ev) {
+            printf("  [%s] #%-2d %-12s %s\n",
+                   status_name(ev.status), ev.id,
+                   ev.name.c_str(), ev.detail.c_str());
+            fflush(stdout);
+        }
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Demo DAG
+// ---------------------------------------------------------------------------
 
 int main() {
     spawn([] {
-        printf("Task Scheduler (3 workers):\n\n");
+        printf("Task Scheduler — priority queue + DAG deps + per-job timeout\n");
+        printf("(Send SIGINT / Ctrl-C to trigger graceful cancellation)\n\n");
 
-        auto sched = start_scheduler(3);
+        // Top-level cancel scope: fires when guard() is called.
+        // Use shared_ptr so the signal watcher can safely call it after the
+        // outer imp has moved on to submitting jobs.
+        auto guard_ptr = std::make_shared<cancel_guard>(cancellation());
 
-        // Progress reporter: prints completions as they arrive.
-        spawn([r = std::move(sched.completions)] {
-            TaskResult result;
-            while (r >> result) {
-                printf("  [done] task %d: %s\n", result.id, result.message.c_str());
+        // Signal watcher: fires guard on SIGINT/SIGTERM.
+        auto sig = signal::notify({SIGINT, SIGTERM});
+        spawn([sig_r = std::move(sig), gp = guard_ptr] () mutable {
+            int s;
+            if (sig_r >> s) {
+                printf("\n  [signal] caught %d — cancelling all jobs\n\n", s);
+                fflush(stdout);
+                (*gp)();
             }
         });
 
-        // Submit tasks with varying priorities and durations.
-        struct { const char* name; int priority; int ms; } tasks[] = {
-            {"compile",     5, 100},
-            {"lint",        3,  50},
-            {"test",        4,  80},
-            {"deploy",      1, 120},
-            {"notify",      2,  30},
-            {"cleanup",     1,  40},
+        auto sched = start_scheduler(3);
+        run_dashboard(std::move(sched.progress));
+
+        // Submit the demo DAG.
+        //
+        //   fetch-config (10)
+        //   fetch-schema (9)
+        //   └─ validate  (8)   deps: 1,2
+        //   compile-a    (7)
+        //   compile-b    (7)
+        //   └─ link      (6)   deps: 3,4,5
+        //   test-unit    (5)   deps: 6
+        //   test-integ   (5)   deps: 6   timeout=200ms, work=250ms → timed_out
+        //   package      (4)   deps: 7,8
+        //   deploy       (3)   deps: 9
+
+        struct JobSpec {
+            int id;
+            const char* name;
+            int priority;
+            std::vector<int> deps;
+            int work_ms;
+            int timeout_ms;   // 0 = no limit
         };
 
-        printf("  Submitting %zu tasks...\n\n", std::size(tasks));
+        JobSpec specs[] = {
+            {1,  "fetch-config", 10, {},        80,  0},
+            {2,  "fetch-schema",  9, {},       120,  0},
+            {3,  "validate",      8, {1,2},     60,  0},
+            {4,  "compile-a",     7, {},       100,  0},
+            {5,  "compile-b",     7, {},        90,  0},
+            {6,  "link",          6, {3,4,5},   70,  0},
+            {7,  "test-unit",     5, {6},        80,  0},
+            {8,  "test-integ",    5, {6},       250, 200},  // will time out
+            {9,  "package",       4, {7,8},      60,  0},
+            {10, "deploy",        3, {9},        90,  0},
+        };
 
-        for (auto& [name, prio, ms] : tasks) {
-            // operator() sends the request and blocks for the response.
-            int id = sched.submit(Task{0, name, prio, ms});
-            printf("  [submit] %-10s (priority=%d, %3dms) -> task %d\n",
-                   name, prio, ms, id);
+        printf("  Submitting %zu jobs...\n\n", std::size(specs));
+
+        for (auto& s : specs) {
+            sched.submit << Job{s.id, s.name, s.priority, s.deps,
+                                std::chrono::milliseconds(s.work_ms),
+                                std::chrono::milliseconds(s.timeout_ms)};
         }
 
-        printf("\n  Waiting for all tasks to complete...\n\n");
-
-        // Drop submit endpoint — dispatcher sees client death, finishes
-        // dispatching, closes work channel, workers drain and exit,
-        // completions channel closes, reporter exits.  Cleanup cascades
-        // through the topology via bidirectional lifecycle observability.
+        // Dropping submit lets the dispatcher know no more jobs are coming.
+        // Dispatcher drains, workers drain, progress_ch closes, dashboard exits.
         sched.submit = {};
     });
 
     schedule();
 
-    printf("\n  All done.\n");
+    printf("\n  Scheduler done.\n");
 }


### PR DESCRIPTION
## Summary

- Rewrites `examples/task_scheduler.cc` to satisfy 🎯T7.5 acceptance criteria: priority queue, worker pool, per-job timeout, dependency DAG, progress reporting over channels, and structured cancellation.
- 10-job demo DAG: `fetch-config/schema → validate → compile-a/b → link → test-unit + test-integ → package → deploy`. `test-integ` deliberately times out (250ms work, 200ms limit), cascading `package` and `deploy` to `failed`.
- SIGINT/SIGTERM fires a top-level `cancel_guard`; all workers inherit the scope via dynamic scoping and emit `cancelled` status on their in-flight jobs.

## Key design decisions

- **Dispatcher imp** uses `alt(sub_r >> job, done_r >> comp)` to multiplex new submissions with completion notifications — demonstrating `alt` over heterogeneous inputs.
- **`dep_tracker`**: lightweight struct tracking outstanding deps per job; `complete()` unblocks dependents, `cancel()` cascades failures.
- **Per-job timeout**: `cancellation(job.timeout)` creates a child scope inside each worker; `timed_out` is caught independently from `canceled` (Ctrl-C).
- **Cascade failure**: when a job times out or fails, `cascade_failure()` walks the dep graph and marks all stuck descendants as `failed` so the scheduler exits cleanly without deadlocking.
- **`cancel_guard` via `shared_ptr`**: the signal-watcher imp shares ownership of the guard with the main imp, so it can safely fire cancellation without a dangling reference.

## Test plan

- [ ] `make build/normal/examples/task_scheduler` → compiles cleanly
- [ ] `./build/normal/examples/task_scheduler` → runs to completion; `test-integ` shows `timed_out`, `package`/`deploy` show `failed`
- [ ] Send `Ctrl-C` mid-run → running jobs show `cancelled`, program exits

🤖 Generated with [Claude Code](https://claude.com/claude-code)