### PR TITLE
Fix QUIC transport on Linux: use EPOLL_CTL_MOD to re-arm one-shot UDP fd events (🎯T21)

### DIFF
--- a/dist/csp.cpp
+++ b/dist/csp.cpp
@@ -3329,6 +3329,13 @@ reader<> Reactor::create_fd_event(int fd, fd_event event) {
               | EPOLLONESHOT;
     ev.data.fd = fd;
     int rc = epoll_ctl(epfd_, EPOLL_CTL_ADD, fd, &ev);
+    if (rc < 0 && errno == EEXIST) {
+        // After EPOLLONESHOT fires, epoll keeps the fd registered but disabled.
+        // Re-arm it with MOD instead of ADD (epoll(7): EPOLL_CTL_ADD returns
+        // EEXIST for an already-registered fd, even one that has been one-shot
+        // disarmed).  kqueue EV_ADD | EV_ONESHOT is idempotent; epoll is not.
+        rc = epoll_ctl(epfd_, EPOLL_CTL_MOD, fd, &ev);
+    }
     assert(rc == 0);
 
     return std::move(ch.r);

--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -520,6 +520,13 @@ reader<> Reactor::create_fd_event(int fd, fd_event event) {
               | EPOLLONESHOT;
     ev.data.fd = fd;
     int rc = epoll_ctl(epfd_, EPOLL_CTL_ADD, fd, &ev);
+    if (rc < 0 && errno == EEXIST) {
+        // After EPOLLONESHOT fires, epoll keeps the fd registered but disabled.
+        // Re-arm it with MOD instead of ADD (epoll(7): EPOLL_CTL_ADD returns
+        // EEXIST for an already-registered fd, even one that has been one-shot
+        // disarmed).  kqueue EV_ADD | EV_ONESHOT is idempotent; epoll is not.
+        rc = epoll_ctl(epfd_, EPOLL_CTL_MOD, fd, &ev);
+    }
     assert(rc == 0);
 
     return std::move(ch.r);

--- a/test/quic.test.cc
+++ b/test/quic.test.cc
@@ -4,11 +4,10 @@
 // Basic QUIC transport tests: listen/dial handshake, echo over a stream,
 // multiple concurrent streams.
 //
-// QUIC currently works on macOS only.  On Linux the reactor's UDP fd
-// registration hits an assertion in `Reactor::create_fd_event`
-// (src/reactor.cc:523) — tracked by 🎯T21.  Skip Linux until fixed.
+// QUIC works on macOS and Linux.  The reactor's epoll branch handles UDP fd
+// re-registration via EPOLL_CTL_MOD when EEXIST is returned after EPOLLONESHOT.
 
-#if defined(CSP_TLS) && defined(__APPLE__)
+#if defined(CSP_TLS)
 
 #include "testutil.h"
 
@@ -188,4 +187,4 @@ TEST_CASE("QUIC---listener-drop-stops-accept") {
     csp::shutdown_runtime();
 }
 
-#endif // CSP_TLS && __APPLE__
+#endif // CSP_TLS


### PR DESCRIPTION
After EPOLLONESHOT fires, epoll keeps the fd registered but disabled.
Re-registering with EPOLL_CTL_ADD returns EEXIST and triggers the assert.
Fix: fall back to EPOLL_CTL_MOD when EPOLL_CTL_ADD returns EEXIST.

kqueue EV_ADD | EV_ONESHOT is idempotent; epoll is not — this is the
key behavioural difference causing the Linux crash.

Also removes the __APPLE__ guard from test/quic.test.cc per 🎯T21 acceptance.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
