### PR TITLE
Release v0.15.0 — 🎯T3.4 context-aware stack depth analysis (retired) + 🎯T23 Phase A

### DIFF
--- a/dist/csp.h
+++ b/dist/csp.h
@@ -7,9 +7,9 @@
 
 /* csp/csp.h */
 
-#define CSP_VERSION "0.14.0"
+#define CSP_VERSION "0.15.0"
 #define CSP_VERSION_MAJOR 0
-#define CSP_VERSION_MINOR 14
+#define CSP_VERSION_MINOR 15
 #define CSP_VERSION_PATCH 0
 
 

--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#define CSP_VERSION "0.14.0"
+#define CSP_VERSION "0.15.0"
 #define CSP_VERSION_MAJOR 0
-#define CSP_VERSION_MINOR 14
+#define CSP_VERSION_MINOR 15
 #define CSP_VERSION_PATCH 0
 
 #include <csp/internal/log.h>


### PR DESCRIPTION
Release prep for v0.15.0.

## 🎯T3.4 — Context-aware stack depth analysis (RETIRED)

Five sub-targets land together, retiring the parent checkpoint.

### Added

- **Profile-guided stack budget calibration** (🎯T3.4.4): the runtime now records per-entry-function high-water marks at every suspend checkpoint. Future spawns of the same entry function use the recorded depth + 50% margin instead of the flat 2 KB indirect-call default. In-memory only; resets on process restart.
- **Small slot class in `StackPool`** (🎯T3.4.1): 16 KB usable + 4 KB guard alongside the existing 124 KB Default. `spawn()` consults `analyse_stack_depth_cached(F, data)` and routes exact analyses (with 2× headroom) to the Small slot. Gated behind `CSP_ANALYSE_STACKS` for staged rollout.
- **Stack-analysis soundness audit** (🎯T3.4.5): `test/stack_analysis_audit.test.cc` reports the analyser-vs-runtime ratio for a curated entry-function set and fails CI on any exact estimate that under-reports the observed high-water. Six cases currently sound.

### Changed

- **Walker resolves PC-relative dispatch + vtable patterns** (🎯T3.4.2): one-time `__TEXT,__text` (excluding `__stubs`) and `__DATA_CONST,__const` discovery via `_dyld_get_image_header` (macOS) / `dl_iterate_phdr` (Linux). BLR/BR through a `PC_RELATIVE` register now dereferences safely after a segment-bounds check; LDR-from-DATA_OFFSET with data promotes to `PC_RELATIVE` when the read lands in our binary, unlocking closure → vptr → method.
- **Walker tracks LDRB/LDRH discriminators + X0–X7 BL forwarding** (🎯T3.4.3): byte/half-word loads materialise CONST so CBZ/CBNZ/TBZ/TBNZ prune. BL emission scans X0–X7 for DATA_OFFSET provenance instead of hard-coding X0.
- `OP_BUDGET` switched to eval-time substitution of `opts.indirect_call_budget` (was walk-time bake-in), decoupling the analyser's program cache from per-spawn budget refinement.

## 🎯T23 Phase A — Per-protocol dist drop-in

Splits the dist amalgamation along protocol boundaries so static linkers drop unused protocols via dead-code elimination.

### Added

- `docs/design/per-protocol-dist.md` documents the five DCE rules.
- Per-protocol implementations live in separate `dist/csp_<proto>.cpp` files (`tls`, `http`, `http2`, `http3`, `ws`, `quic`), plus the QUIC C99 adapter `dist/ngtcp2_crypto_picotls_minicrypto.c`.
- Phase B sub-targets filed: 🎯T23.1 (unified `enable()` factory + `csp_net.h` front-door), 🎯T23.2 (`scripts/vendor-deps.sh`), 🎯T23.3 (CI link-line matrix), 🎯T23.4 (build-time lint enforcing Rule 5).

### Changed

- `scripts/amalgamate.py` generates the new per-protocol layout. The channels-only `csp.cpp` + `csp_globals.cpp` drop-in is unchanged for users who don't want any protocols.
- `dist/csp.cpp` (front-door TU) emits zero references to protocol-specific symbols — Rule 5 holds by grep.

## Housekeeping

- Removed `docs/audit-log.md` (#60).

## Test plan

- [x] `make` — 743/743 normal-mode tests pass (+14 new since v0.14.0)
- [x] `make test-dist CSP_TLS=0` — channels-only dist tests pass
- [x] `make test-dist CSP_TLS=1` — full dist tests pass
- [x] Stack-analysis soundness gate: 6/6 cases sound
- [x] CI must pass before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
