### PR TITLE
🎯T23.2: scripts/vendor-deps.sh for dist drop-in users

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,15 @@ All dist files are generated from `src/`/`include/` by `scripts/amalgamate.py`
 C99 TU; the script copies it verbatim into `dist/` since it cannot be
 amalgamated into C++ alongside the other protocol implementations.
 
+External users fetch the third-party libraries via
+[`scripts/vendor-deps.sh`](scripts/vendor-deps.sh), which clones llhttp,
+picotls, nghttp2, nghttp3, ngtcp2, and wslay at pinned commits into
+`vendor/<name>/` and generates the autotools-style version headers.
+Per-protocol flags (`--http`, `--http2`, `--http3`, `--ws`, `--quic`,
+`--tls`, `--all`) match the drop-in `.cpp` files. The script is the
+canonical answer to "how do I get the deps the dist files need?" and is
+referenced from `dist/AGENTS-CSP.md`.
+
 ### Development source layout
 
 - **include/csp/csp.h** — Core API: `spawn`, `schedule`, `yield`, `chan`,

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -301,6 +301,11 @@ targets:
         83defd6  docs: document per-protocol dist drop-in model (🎯T23)
 
       Follow-up sub-targets filed: T23.1 (enable() factory + csp_net.h front-door), T23.2 (vendor-deps.sh), T23.3 (CI matrix for subset link verification), T23.4 (build-time lint enforcing front-door TU has no protocol-specific symbol refs).
+    depends_on:
+    - T23.1
+    - T23.2
+    - T23.3
+    - T23.4
     origin: manual
     discovered: 2026-05-09
   T23.1:
@@ -316,13 +321,11 @@ targets:
     - Existing direct-call APIs (csp::http::serve, csp::tls::context, csp::quic::listen, …) continue to work unchanged so existing users don't migrate
     - API design covers ALPN negotiation (TLS + ALPN choosing between http2 and http/1.1) and the interaction between enable(tls::cert(...)) and enable(http::route(...)) options
     context: 'Phase B of 🎯T23. The Phase A file-split (committed in this worktree) gives users per-protocol cherry-picking via the linker today; this sub-target adds the unified-server convenience layer the original T23 acceptance criteria call for. Held back from Phase A because (a) the API needs careful design — what happens when incompatible enable()s are combined, how does ALPN negotiation interact with the option list, does enable(http) imply enable(tls) for serve_tls? — and (b) keeping it separate let Phase A land mechanically and unblock downstream users immediately. Implementation plan: each protocol .cpp defines a free function `csp::<proto>::enable(...)` that constructs a protocol_option holding (void* config_blob, void(*apply)(server_state&, void* config_blob)). The unified csp::net::serve walks the option list, calls each apply() — front-door TU references only the apply function pointer (so its TU contains no name-level reference to the protocol implementation). Discovery: doing both phases in one session would either slip the file split or rush the API design.'
-    depends_on:
-    - T23
     origin: manual
     discovered: 2026-05-17
   T23.2:
     name: scripts/vendor-deps.sh fetches and builds vendored protocol libraries with per-protocol flags
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
     acceptance:
@@ -333,10 +336,9 @@ targets:
     - README or comments at the top of the script document the matrix of which library is needed for which protocol drop-in
     - 'Run end-to-end on a fresh checkout: clone, ./scripts/vendor-deps.sh --all, compile a sample app against the dist + the populated vendor/, the binary builds and runs'
     context: 'A user that takes the dist drop-in today must separately fetch six C99 libraries and figure out which headers to expose. Automating this is the second-biggest Phase A gap (after the enable() factory). Held back from the Phase A landing because the script needs care: each library has its own build-system mess (autotools/cmake), the version.h substitutions duplicate Makefile logic, and getting the vendor/ layout right enough that csp_<proto>.cpp builds without further hand-edits takes iteration. Prerequisite for the CI matrix in T23.3.'
-    depends_on:
-    - T23
     origin: manual
     discovered: 2026-05-17
+    achieved: 2026-05-19
   T23.3:
     name: CI matrix builds subset configurations and verifies link line excludes unselected protocols
     status: identified
@@ -363,8 +365,6 @@ targets:
     - The lint also catches the equivalent on src/ files that get folded into dist/csp.cpp by the amalgamation script (so the violation is caught at source-edit time, not after `make dist`)
     - 'Test fixture: a deliberately-violating commit fails CI; reverting it passes again'
     context: 'Rule 5 of the five DCE rules is the easiest to violate accidentally — someone refactoring net.cc adds a TLS-aware fast path guarded by #ifdef CSP_TLS and the front door starts pulling in TLS. A regex lint over the front-door TU + all amalgamated source files catches this at CI time. Cheap; depends on nothing else; can land any time after Phase A.'
-    depends_on:
-    - T23
     origin: manual
     discovered: 2026-05-17
   T24:

--- a/dist/AGENTS-CSP.md
+++ b/dist/AGENTS-CSP.md
@@ -1032,6 +1032,26 @@ files cherry-pick which implementations the linker keeps. Skip a `.cpp`
 file and its third-party deps drop out of the link (provided you have
 linker dead-code elimination enabled — see below).
 
+### Fetching the vendored libraries
+
+CSP ships
+[`scripts/vendor-deps.sh`](https://github.com/marcelocantos/csp/blob/master/scripts/vendor-deps.sh)
+to fetch known-good versions of the third-party libraries the per-protocol
+drop-ins need. Drop the script into your project alongside `dist/` and run:
+
+```bash
+./scripts/vendor-deps.sh --all                 # every library
+./scripts/vendor-deps.sh --http --ws           # HTTP/1.1 + WebSocket
+./scripts/vendor-deps.sh --http3               # HTTP/3 (pulls QUIC + TLS)
+```
+
+The script clones each library to `vendor/<name>/` at a pinned commit and
+generates the version headers (`nghttp2ver.h`, `version.h`, `wslayver.h`)
+that are normally produced by autotools/cmake. The include paths in the
+compile recipes below match what the script produces.
+
+### Compile recipes
+
 Compile with C++20 and libc++. Channels-only:
 
 ```bash

--- a/scripts/vendor-deps.sh
+++ b/scripts/vendor-deps.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# vendor-deps.sh — fetch third-party libraries needed by the CSP dist drop-in.
+#
+# CSP ships as a small set of source files in dist/ that users vendor into
+# their own project. The per-protocol .cpp files depend on third-party C99
+# libraries (llhttp, picotls, nghttp2, etc.). This script fetches known-good
+# versions of those libraries into vendor/ with the layout the drop-in's
+# documented compile recipes (see dist/AGENTS-CSP.md "Integration") expect.
+#
+# Usage:
+#   ./scripts/vendor-deps.sh --all                 fetch every library
+#   ./scripts/vendor-deps.sh --http --ws           HTTP/1.1 + WebSocket
+#   ./scripts/vendor-deps.sh --http3               HTTP/3 (pulls QUIC + TLS)
+#   ./scripts/vendor-deps.sh --help                show this help
+#
+# Flags map to drop-in protocol .cpp files:
+#
+#   Flag       Drop-in       Libraries fetched (transitive)
+#   --------   -----------   -----------------------------------------------
+#   --tls      csp_tls.cpp   picotls
+#   --http     csp_http.cpp  llhttp
+#   --http2    csp_http2.cpp nghttp2 (+ picotls for serve_tls / ALPN)
+#   --ws       csp_ws.cpp    wslay (+ llhttp for the upgrade handshake)
+#   --quic     csp_quic.cpp  ngtcp2, picotls
+#   --http3    csp_http3.cpp nghttp3, ngtcp2, picotls
+#   --all      everything    every library above
+#
+# Output layout (matches dist/AGENTS-CSP.md include paths):
+#
+#   vendor/llhttp/      — clone of nodejs/llhttp
+#   vendor/picotls/     — clone of h2o/picotls (cifra + micro-ecc included)
+#   vendor/nghttp2/     — clone of nghttp2/nghttp2 (with nghttp2ver.h generated)
+#   vendor/nghttp3/     — clone of ngtcp2/nghttp3   (with version.h generated)
+#   vendor/ngtcp2/      — clone of ngtcp2/ngtcp2    (with version.h generated)
+#   vendor/wslay/       — clone of tatsuhiro-t/wslay (with wslayver.h stub)
+#
+# Versions are pinned to commits that the CSP project's own CI builds against.
+# Re-running the script is idempotent — already-fetched libraries at the
+# pinned commit are skipped.
+#
+# Requires: git, sed. Works on macOS and Linux.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Pinned versions. These commits match the CSP repo's own submodule pins as
+# of the script's last update. Bumping a pin requires re-testing the dist
+# build against the new revision.
+
+PIN_LLHTTP_TAG='release/v9.3.1'                                # nodejs/llhttp
+PIN_PICOTLS='bb37a1709889eba08c6bfcdf5ef477e3d7008302'         # h2o/picotls
+PIN_NGHTTP2='7d8e587ad4e8da4b772725bd345d48ec0d42b2ec'         # v1.69.0-40
+PIN_NGHTTP3='e7a5a617ddf04b46eb7ce0ddaf3e318b1b46017d'         # v1.15.0-27
+PIN_NGTCP2='88f9f6576226ea7fd4aeb81ce809a71a3ae03413'          # v1.22.0-85
+PIN_WSLAY_TAG='release-1.1.1'                                  # tatsuhiro-t/wslay
+
+NGHTTP2_VERSION_STR='1.69.90'
+NGHTTP2_VERSION_NUM='0x01455a'
+NGHTTP3_VERSION_STR='1.15.0'
+NGHTTP3_VERSION_NUM='0x010f00'
+NGTCP2_VERSION_STR='1.22.0'
+NGTCP2_VERSION_NUM='0x011600'
+
+# Repo root = parent of scripts/.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+VENDOR_DIR="$REPO_ROOT/vendor"
+
+# Selected protocols (set by argument parsing).
+WANT_TLS=0
+WANT_HTTP=0
+WANT_HTTP2=0
+WANT_HTTP3=0
+WANT_WS=0
+WANT_QUIC=0
+
+# ---------------------------------------------------------------------------
+
+log() { printf '[vendor-deps] %s\n' "$*" >&2; }
+die() { printf '[vendor-deps] error: %s\n' "$*" >&2; exit 1; }
+
+usage() {
+    sed -n '2,/^set -euo pipefail$/p' "$0" | sed 's/^# \{0,1\}//;$d' >&2
+    exit "${1:-0}"
+}
+
+while (( $# )); do
+    case "$1" in
+        --tls)     WANT_TLS=1 ;;
+        --http)    WANT_HTTP=1 ;;
+        --http2)   WANT_HTTP2=1 ;;
+        --http3)   WANT_HTTP3=1 ;;
+        --ws)      WANT_WS=1 ;;
+        --quic)    WANT_QUIC=1 ;;
+        --all)
+            WANT_TLS=1; WANT_HTTP=1; WANT_HTTP2=1; WANT_HTTP3=1
+            WANT_WS=1;  WANT_QUIC=1
+            ;;
+        -h|--help) usage 0 ;;
+        *)         log "unknown argument: $1"; usage 1 ;;
+    esac
+    shift
+done
+
+if (( WANT_TLS + WANT_HTTP + WANT_HTTP2 + WANT_HTTP3 + WANT_WS + WANT_QUIC == 0 )); then
+    log 'no protocol flags given; pass --all or one of --tls --http --http2 --http3 --ws --quic'
+    usage 1
+fi
+
+# Resolve transitive dependencies.
+(( WANT_HTTP3 )) && { WANT_QUIC=1; }                       # http3 → quic + nghttp3
+(( WANT_QUIC ))  && { WANT_TLS=1; }                        # quic  → tls
+(( WANT_HTTP2 )) && { WANT_TLS=1; }                        # http2 → tls (for serve_tls)
+(( WANT_WS ))    && { WANT_HTTP=1; }                       # ws    → http (for upgrade)
+
+command -v git >/dev/null || die 'git not found in PATH'
+command -v sed >/dev/null || die 'sed not found in PATH'
+
+mkdir -p "$VENDOR_DIR"
+
+# ---------------------------------------------------------------------------
+# fetch_repo <local-dir> <upstream-url> <ref>
+#
+# Clones <upstream-url> to vendor/<local-dir> and checks out <ref>. If the
+# directory already exists and is at the requested ref, skips. Otherwise
+# fetches and updates.
+
+fetch_repo() {
+    local name="$1" url="$2" ref="$3"
+    local dest="$VENDOR_DIR/$name"
+
+    if [[ -d "$dest/.git" ]]; then
+        local head
+        head="$(git -C "$dest" rev-parse HEAD)"
+        if [[ "$head" == "$ref" ]] || git -C "$dest" describe --tags --exact-match "$head" 2>/dev/null | grep -qx "$ref"; then
+            log "$name already at $ref — skipping"
+            return
+        fi
+        log "$name updating to $ref"
+        git -C "$dest" fetch --tags --depth=1 origin "$ref" 2>/dev/null || git -C "$dest" fetch --tags origin
+    else
+        log "$name cloning $url"
+        git clone --filter=blob:none "$url" "$dest"
+    fi
+
+    git -C "$dest" checkout --quiet "$ref"
+    git -C "$dest" submodule update --init --recursive --quiet
+}
+
+# version_h <path> <PACKAGE_VERSION> <PACKAGE_VERSION_NUM>
+#
+# Generates a version.h from version.h.in by substituting the @PACKAGE_VERSION@
+# and @PACKAGE_VERSION_NUM@ placeholders. nghttp2/nghttp3/ngtcp2 all use this
+# scheme; their build systems would normally produce these via autotools.
+
+version_h() {
+    local in="$1.in" out="$1" ver_str="$2" ver_num="$3"
+    [[ -f "$in" ]] || die "missing $in"
+    sed -e "s/@PACKAGE_VERSION@/$ver_str/" \
+        -e "s/@PACKAGE_VERSION_NUM@/$ver_num/" \
+        "$in" > "$out"
+    log "$(basename "$out") generated"
+}
+
+# ---------------------------------------------------------------------------
+# Per-library fetchers.
+
+fetch_llhttp() {
+    fetch_repo llhttp https://github.com/nodejs/llhttp.git "$PIN_LLHTTP_TAG"
+}
+
+fetch_picotls() {
+    fetch_repo picotls https://github.com/h2o/picotls.git "$PIN_PICOTLS"
+    # cifra and micro-ecc are checked into picotls as subtrees (not submodules),
+    # so the recursive update above is sufficient.
+    [[ -d "$VENDOR_DIR/picotls/deps/cifra" ]]     || die 'picotls/deps/cifra missing after clone'
+    [[ -d "$VENDOR_DIR/picotls/deps/micro-ecc" ]] || die 'picotls/deps/micro-ecc missing after clone'
+}
+
+fetch_nghttp2() {
+    fetch_repo nghttp2 https://github.com/nghttp2/nghttp2.git "$PIN_NGHTTP2"
+    version_h \
+        "$VENDOR_DIR/nghttp2/lib/includes/nghttp2/nghttp2ver.h" \
+        "$NGHTTP2_VERSION_STR" "$NGHTTP2_VERSION_NUM"
+}
+
+fetch_nghttp3() {
+    fetch_repo nghttp3 https://github.com/ngtcp2/nghttp3.git "$PIN_NGHTTP3"
+    version_h \
+        "$VENDOR_DIR/nghttp3/lib/includes/nghttp3/version.h" \
+        "$NGHTTP3_VERSION_STR" "$NGHTTP3_VERSION_NUM"
+}
+
+fetch_ngtcp2() {
+    fetch_repo ngtcp2 https://github.com/ngtcp2/ngtcp2.git "$PIN_NGTCP2"
+    version_h \
+        "$VENDOR_DIR/ngtcp2/lib/includes/ngtcp2/version.h" \
+        "$NGTCP2_VERSION_STR" "$NGTCP2_VERSION_NUM"
+}
+
+fetch_wslay() {
+    fetch_repo wslay https://github.com/tatsuhiro-t/wslay.git "$PIN_WSLAY_TAG"
+    # wslay's wslayver.h is normally generated by autotools. We ship a static
+    # stub that matches the latest tagged release; the drop-in only reads
+    # the version macros for diagnostics, never for ABI selection.
+    cat > "$VENDOR_DIR/wslay/lib/includes/wslay/wslayver.h" <<'EOF'
+/* wslay version header — generated stub for the dist drop-in build. */
+#ifndef WSLAY_VERSION_H
+#define WSLAY_VERSION_H
+
+#define WSLAY_VERSION       "1.1.1"
+#define WSLAY_VERSION_MAJOR 1
+#define WSLAY_VERSION_MINOR 1
+#define WSLAY_VERSION_PATCH 1
+#define WSLAY_VERSION_NUM   0x010101
+
+#endif /* WSLAY_VERSION_H */
+EOF
+    log 'wslayver.h stub written'
+}
+
+# ---------------------------------------------------------------------------
+# Dispatch.
+
+(( WANT_TLS ))   && fetch_picotls
+(( WANT_HTTP ))  && fetch_llhttp
+(( WANT_HTTP2 )) && fetch_nghttp2
+(( WANT_HTTP3 )) && fetch_nghttp3
+(( WANT_QUIC ))  && fetch_ngtcp2
+(( WANT_WS ))    && fetch_wslay
+
+log 'done.'


### PR DESCRIPTION
## Summary

- New `scripts/vendor-deps.sh` clones the third-party C99 libraries the dist drop-in needs (llhttp, picotls, nghttp2, nghttp3, ngtcp2, wslay) at pinned commits matching the project's own submodule pins, into a flat `vendor/<name>/` layout that matches the include paths in `dist/AGENTS-CSP.md`.
- Per-protocol flags map to drop-in `.cpp` files: `--tls`, `--http`, `--http2`, `--http3`, `--ws`, `--quic`, `--all`. Transitive deps resolved internally (`--http3` pulls QUIC + TLS; `--ws` pulls HTTP for the upgrade handshake; etc.).
- Generates the autotools-style version headers (`nghttp2ver.h`, `version.h` for nghttp3/ngtcp2, `wslayver.h`) by sed-substituting placeholders against the version constants the project Makefile uses.
- Wired into `dist/AGENTS-CSP.md` (new "Fetching the vendored libraries" subsection) and project `CLAUDE.md` so users discover it from the documented entry points.
- Retires 🎯T23.2; flips 🎯T23 sub-target dependency edges so the sub-targets are now blockers of 🎯T23 (was: 🎯T23 blocking the sub-targets, which was circular given T23's acceptance was deferred to them).

## Test plan

- [x] End-to-end on a fresh checkout in `/tmp`: `./scripts/vendor-deps.sh --all` populates `vendor/` (6 libs, ~2:14 wall clock).
- [x] All 8 per-protocol `.cpp` files (`csp.cpp`, `csp_globals.cpp`, `csp_http.cpp`, `csp_http2.cpp`, `csp_ws.cpp`, `csp_tls.cpp`, `csp_quic.cpp`, `csp_http3.cpp`) compile cleanly against the populated vendor tree.
- [x] Channels-only sample binary links and runs.
- [x] `python3 scripts/check_md_links.py` — all links OK across 148 Markdown files.
- [ ] CI green (full `make` matrix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)