### PR TITLE
🎯T23 Phase B — factory API + lint + CI subset matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,47 @@ jobs:
               --args ./build/dist/csp_tests 2>&1 || true
           fi
 
+  # --- Subset-link DCE check (🎯T23.3) ---
+  # Verifies that an external user who picks only some protocol drop-ins
+  # ends up with a binary that contains only those protocols' libraries.
+  # Each matrix job fetches the matching libraries via vendor-deps.sh,
+  # compiles the dist drop-in + a sample, and uses `nm` to assert that
+  # other protocols' symbol prefixes (llhttp_, nghttp2_, ngtcp2_, wslay_,
+  # ptls_) are absent from the final binary.
+  subset-link:
+    name: subset-link (${{ matrix.subset }} on ${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        subset: [channels, http, http+ws, quic, full]
+        include:
+          - os: macos-14
+            name: macOS arm64
+          - os: ubuntu-24.04
+            name: Linux x86_64
+            packages: clang-18 libc++-18-dev libc++abi-18-dev
+            cc_override: 'CXX=clang++-18 CC=clang-18'
+
+    steps:
+      - uses: actions/checkout@v4
+        # Deliberately no `submodules` and no `lfs` — the whole point of
+        # this job is to simulate an external user who took only the dist
+        # drop-in plus scripts/vendor-deps.sh.
+
+      - name: Install Linux dependencies
+        if: matrix.packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ${{ matrix.packages }}
+          # Make clang-18 the default `cc` / `c++` for the script.
+          echo "CC=clang-18" >> "$GITHUB_ENV"
+          echo "CXX=clang++-18" >> "$GITHUB_ENV"
+
+      - name: Run subset_check.sh
+        run: scripts/subset_check.sh "${{ matrix.subset }}"
+
   # --- Windows: CMake-based build + test ---
   windows:
     name: Windows x86_64

--- a/Makefile
+++ b/Makefile
@@ -512,15 +512,24 @@ BENCH_TARGET := $(BUILDDIR)/csp_bench
 # --- Rules ---
 
 .PHONY: test build bench test-dist check check-tla-tags check-md-links diagrams examples run-examples run-examples-ci dist iwyu clean \
-       docker-test docker-test-arm64 docker-test-x86 docker-image docker-clean bullseye
+       docker-test docker-test-arm64 docker-test-x86 docker-image docker-clean bullseye lint-frontdoor
 
 # Explicit default — keep `make` (no args) running the full test suite.
 # Without this, the `bullseye` rule below would become the default target
 # by virtue of appearing first.
 .DEFAULT_GOAL := test
 
-test: $(TARGET) check-md-links
+test: $(TARGET) check-md-links lint-frontdoor
 	./$(TARGET)
+
+# --- Front-door TU lint (🎯T23.4) ---
+# Enforces Rule 5 of the per-protocol DCE model: dist/csp.cpp (and the
+# src/ files amalgamated into it) must reference no csp::<proto>::
+# symbols. See docs/design/per-protocol-dist.md §5. Fast (~50 ms), runs
+# on every build so violations are caught at source-edit time, not at
+# make-dist time.
+lint-frontdoor:
+	@python3 scripts/lint_frontdoor.py
 
 # --- Standing invariants (consumed by `bullseye_convergence`) ---
 # Exit 0 if all green, non-zero on first violation. Stdout is relayed
@@ -538,6 +547,8 @@ bullseye:
 	 (echo "✗ tests (exit $$? — timeout=$(BULLSEYE_TEST_TIMEOUT)s)"; exit 1)
 	@python3 scripts/check_md_links.py >/dev/null && echo "✓ md-links" || \
 	 (echo "✗ md-links"; python3 scripts/check_md_links.py; exit 1)
+	@python3 scripts/lint_frontdoor.py >/dev/null && echo "✓ lint-frontdoor" || \
+	 (echo "✗ lint-frontdoor"; python3 scripts/lint_frontdoor.py; exit 1)
 	@test -z "$$(git status --porcelain)" && echo "✓ clean tree" || \
 	 (echo "✗ dirty tree"; git status --short; exit 1)
 

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -261,7 +261,7 @@ targets:
     discovered: 2026-04-30
   T23:
     name: Per-protocol dist drop-in supports linker dead-code elimination
-    status: converging
+    status: achieved
     value: 0.0
     cost: 0.0
     acceptance:
@@ -308,9 +308,10 @@ targets:
     - T23.4
     origin: manual
     discovered: 2026-05-09
+    achieved: 2026-05-20
   T23.1:
     name: Unified csp::net::serve(opts) + per-protocol enable() factory API
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
     acceptance:
@@ -323,6 +324,7 @@ targets:
     context: 'Phase B of 🎯T23. The Phase A file-split (committed in this worktree) gives users per-protocol cherry-picking via the linker today; this sub-target adds the unified-server convenience layer the original T23 acceptance criteria call for. Held back from Phase A because (a) the API needs careful design — what happens when incompatible enable()s are combined, how does ALPN negotiation interact with the option list, does enable(http) imply enable(tls) for serve_tls? — and (b) keeping it separate let Phase A land mechanically and unblock downstream users immediately. Implementation plan: each protocol .cpp defines a free function `csp::<proto>::enable(...)` that constructs a protocol_option holding (void* config_blob, void(*apply)(server_state&, void* config_blob)). The unified csp::net::serve walks the option list, calls each apply() — front-door TU references only the apply function pointer (so its TU contains no name-level reference to the protocol implementation). Discovery: doing both phases in one session would either slip the file split or rush the API design.'
     origin: manual
     discovered: 2026-05-17
+    achieved: 2026-05-20
   T23.2:
     name: scripts/vendor-deps.sh fetches and builds vendored protocol libraries with per-protocol flags
     status: achieved
@@ -341,7 +343,7 @@ targets:
     achieved: 2026-05-19
   T23.3:
     name: CI matrix builds subset configurations and verifies link line excludes unselected protocols
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
     acceptance:
@@ -354,9 +356,10 @@ targets:
     - T23.2
     origin: manual
     discovered: 2026-05-17
+    achieved: 2026-05-20
   T23.4:
     name: Build-time lint enforces front-door TU has no protocol-specific symbol references
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
     acceptance:
@@ -367,6 +370,7 @@ targets:
     context: 'Rule 5 of the five DCE rules is the easiest to violate accidentally — someone refactoring net.cc adds a TLS-aware fast path guarded by #ifdef CSP_TLS and the front door starts pulling in TLS. A regex lint over the front-door TU + all amalgamated source files catches this at CI time. Cheap; depends on nothing else; can land any time after Phase A.'
     origin: manual
     discovered: 2026-05-17
+    achieved: 2026-05-20
   T24:
     name: Pre-built CSP library artefacts published with each GitHub Release
     status: identified

--- a/dist/AGENTS-CSP.md
+++ b/dist/AGENTS-CSP.md
@@ -1114,6 +1114,24 @@ only way to make its TU live. See
 [`docs/design/per-protocol-dist.md`](https://github.com/marcelocantos/csp/blob/master/docs/design/per-protocol-dist.md)
 for the full discussion.
 
+There are two ways to make a protocol live:
+
+1. **Direct call** — `csp::http::serve(8080, {...})` etc. The existing
+   API; what every example in this document uses. Each direct call
+   pulls its protocol's TU into the link automatically.
+2. **Factory API** (🎯T23.1) —
+   `csp::net::serve(8080, {csp::http::enable()})`. Each protocol provides
+   an `enable()` factory returning a `csp::net::protocol_option` carrying
+   a function-pointer `apply` that the unified `csp::net::serve` walks.
+   The front-door TU sees only the function pointer, so adding a new
+   protocol doesn't add any name-level dependency to `csp.cpp`.
+
+The two are interchangeable for single-protocol cases; the factory form
+exists primarily so cross-protocol composition (ALPN-negotiated HTTP/1.1
+vs HTTP/2 on a TLS socket, etc.) has a single entry point. Current Phase B
+ships with `csp::http::enable()` implemented; other protocols' factories
+land as needed.
+
 The contract is enforced in CI by
 [`scripts/subset_check.sh`](https://github.com/marcelocantos/csp/blob/master/scripts/subset_check.sh)
 (🎯T23.3), which builds subset configurations (channels-only, http-only,

--- a/dist/AGENTS-CSP.md
+++ b/dist/AGENTS-CSP.md
@@ -1114,5 +1114,16 @@ only way to make its TU live. See
 [`docs/design/per-protocol-dist.md`](https://github.com/marcelocantos/csp/blob/master/docs/design/per-protocol-dist.md)
 for the full discussion.
 
+The contract is enforced in CI by
+[`scripts/subset_check.sh`](https://github.com/marcelocantos/csp/blob/master/scripts/subset_check.sh)
+(🎯T23.3), which builds subset configurations (channels-only, http-only,
+http+ws, quic-only, full) on macOS arm64 and Linux x86_64. Each job runs
+`vendor-deps.sh` for that subset's libraries, compiles the drop-in plus a
+small sample, links with `-dead_strip` / `--gc-sections`, and uses `nm` to
+assert that libraries belonging to unselected protocols (`llhttp_`,
+`nghttp2_`, `nghttp3_`, `ngtcp2_`, `wslay_`, `ptls_`) are absent from the
+final binary. A regression that pulls an unselected protocol's symbols into
+the front-door TU trips a clear, named CI failure.
+
 Reference this file from your project's `CLAUDE.md` or `AGENTS.md` to
 give coding agents CSP expertise.

--- a/dist/csp.cpp
+++ b/dist/csp.cpp
@@ -2910,6 +2910,30 @@ connection dial(const std::string& host, const std::string& service) {
     throw csp::error("dial failed: all addresses exhausted");
 }
 
+// --- Unified server (🎯T23.1) -----------------------------------------
+//
+// Walks the option list, calling each `apply()` so the protocol can stash
+// its server handle into `out.protocol_servers`. The front-door TU never
+// references any `csp::<proto>::` symbol by name — every per-protocol
+// behaviour is reached through the function pointer in `protocol_option`.
+// That keeps Rule 5 of the per-protocol DCE model intact: an `enable()`
+// the user never calls leaves its protocol TU dead, and the linker drops
+// the third-party libraries that protocol depended on.
+
+server serve(uint16_t port, std::initializer_list<protocol_option> opts) {
+    server out{.port = port, .protocol_servers = {}};
+    apply_context ctx{.port = port, .out = &out};
+    for (const auto& opt : opts) {
+        if (opt.apply != nullptr) {
+            opt.apply(ctx, opt.config);
+        }
+        if (opt.destroy != nullptr) {
+            opt.destroy(opt.config);
+        }
+    }
+    return out;
+}
+
 } // namespace csp::net
 
 /* reactor.cc */

--- a/dist/csp.h
+++ b/dist/csp.h
@@ -3628,6 +3628,7 @@ inline csp::reader<std::string> lines(csp::io::fd_t fd,
 
 }
 
+#include <initializer_list>
 
 namespace csp::net {
 
@@ -3680,6 +3681,59 @@ listener listen(const std::string& addr, uint16_t port,
 
 connection dial(const std::string& host, uint16_t port);
 connection dial(const std::string& host, const std::string& service);
+
+// --- Unified server entry point (🎯T23.1) ------------------------------
+//
+// `csp::net::serve(port, {tls::enable(...), http::enable(), ...})` starts
+// a server on `port` running the per-protocol stacks named in the option
+// list. The option list is built from per-protocol `enable()` factories
+// living in their own drop-in .cpp files — calling, e.g., `http::enable()`
+// is what keeps `csp_http.cpp` (and llhttp) live in the link; an enable()
+// that's not called leaves its protocol TU dead and the third-party
+// library it depends on dropped by `-dead_strip` / `--gc-sections`.
+//
+// The opaque `protocol_option` struct carries an `apply()` function pointer
+// — the only mechanism the front-door TU (`csp.cpp`) uses to invoke
+// per-protocol behaviour — so Rule 5 of the per-protocol DCE model holds
+// (docs/design/per-protocol-dist.md §5).
+//
+// Phase B (initial release): single-protocol case fully supported. ALPN
+// negotiation for `tls` + `{http, http2}` and the interaction between
+// multiple option types is follow-up work — see 🎯T23.1's context for
+// the design space.
+
+struct server;
+
+// Context handed to each `protocol_option::apply()`. Apply functions stash
+// their per-protocol server handles into `out->protocol_servers` (typed,
+// retrievable via `std::any_cast`).
+struct apply_context {
+    uint16_t port;       // port the user asked for
+    server*  out;        // destination for the protocol-specific server handles
+};
+
+// Opaque option produced by `csp::<proto>::enable()` factories. The
+// front-door TU references only the `apply` function pointer — never the
+// protocol's namespace by name — which keeps Rule 5 intact.
+struct protocol_option {
+    void* config = nullptr;
+    void (*apply)(apply_context&, void* config) = nullptr;
+    void (*destroy)(void* config) = nullptr;   // nullptr = no cleanup
+};
+
+// Unified server handle. Holds typed protocol-server objects (each
+// protocol's `serve()` return type) inside a `std::any` so the front-
+// door TU stays protocol-agnostic. Callers cast back with `std::any_cast`:
+//
+//     auto srv = csp::net::serve(8080, {csp::http::enable()});
+//     auto& http_srv = std::any_cast<csp::http::server&>(srv.protocol_servers[0]);
+//
+struct server {
+    uint16_t              port;
+    std::vector<std::any> protocol_servers;
+};
+
+server serve(uint16_t port, std::initializer_list<protocol_option> opts);
 
 } // namespace csp::net
 
@@ -3786,6 +3840,20 @@ struct server {
 // connection. Dropping the reader stops accepting.
 server serve(uint16_t port, serve_options opts = {});
 server serve(const std::string& addr, uint16_t port, serve_options opts = {});
+
+// --- Factory for csp::net::serve (🎯T23.1) ---
+//
+// Returns a `csp::net::protocol_option` that, when passed to
+// `csp::net::serve(port, {...})`, starts an HTTP/1.1 server on that port
+// and stashes the resulting `csp::http::server` in
+// `csp::net::server::protocol_servers` (retrievable with
+// `std::any_cast<csp::http::server&>`).
+//
+// Calling this factory is what keeps `csp_http.cpp` and llhttp live in
+// the link; a build that doesn't reference `csp::http::enable()` (and
+// doesn't call `csp::http::serve` directly) drops both via `-dead_strip`
+// / `--gc-sections`.
+csp::net::protocol_option enable(serve_options opts = {});
 
 // --- Client ---
 
@@ -8487,7 +8555,6 @@ connection dial(const std::string& host, uint16_t port,
 #ifndef _WIN32
 
 
-#include <initializer_list>
 
 namespace csp::signal {
 

--- a/dist/csp_http.cpp
+++ b/dist/csp_http.cpp
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <atomic>
 #include <cctype>
+#include <memory>
 #include <sstream>
 #include <string>
 
@@ -784,6 +785,37 @@ response fetch(
         state.status_code,
         std::move(state.headers),
         std::move(state.body)};
+}
+
+// --- Factory for csp::net::serve (🎯T23.1) ---
+//
+// The `apply()` lambda lives in this TU (csp_http.cpp in the dist drop-in),
+// so referencing `csp::http::enable()` from user code pulls the entire TU
+// — including its llhttp_* references — into the link. The front-door TU
+// (csp.cpp) reaches enable() only through the function-pointer-shaped
+// `protocol_option`, which leaves Rule 5 (no protocol symbols in the front
+// door) intact.
+
+csp::net::protocol_option enable(serve_options opts) {
+    auto* cfg = new serve_options(std::move(opts));
+    return csp::net::protocol_option{
+        .config = cfg,
+        .apply = [](csp::net::apply_context& ctx, void* config) {
+            auto* c = static_cast<serve_options*>(config);
+            // Start a real HTTP/1.1 server and hand its handle to the
+            // unified net::server. csp::http::server is move-only (its
+            // endpoints reader can't be copied), so we wrap it in a
+            // shared_ptr to fit std::any's copyable requirement. Callers
+            // retrieve the typed handle via
+            // std::any_cast<std::shared_ptr<csp::http::server>>(s.protocol_servers[0]).
+            ctx.out->protocol_servers.emplace_back(
+                std::make_shared<csp::http::server>(
+                    csp::http::serve(ctx.port, *c)));
+        },
+        .destroy = [](void* config) {
+            delete static_cast<serve_options*>(config);
+        },
+    };
 }
 
 } // namespace csp::http

--- a/docs/design/per-protocol-dist.md
+++ b/docs/design/per-protocol-dist.md
@@ -219,13 +219,30 @@ from the immediate file-split deliverable. The migration plan:
    direct-call API (`csp::http::serve`, `csp::tls::context`, …) continues to
    work unchanged; per-function DCE handles the no-call case. Document the
    five rules and gate them with code review + future lint.
-2. **Phase B (follow-up sub-target)**: Introduce the `enable()` factory
-   pattern + a unified `csp::net::serve(uint16_t port, std::initializer_list<csp::net::protocol_option>)` entry point. Each `enable()` factory lives in its own protocol TU and returns an opaque `protocol_option` (a
-   `void*` config + a function-pointer "apply"). The unified `serve` walks the
-   options, dispatches to the apply function pointers, and starts the right
-   protocol stack. Critically: the unified `serve` lives in `csp_net.cpp`
-   (the front-door TU) and references no protocol symbols by name — only via
-   the type-erased function pointers carried in the `protocol_option`s.
+2. **Phase B (initial release — 🎯T23.1)**: Introduce the `enable()`
+   factory pattern + a unified
+   `csp::net::serve(uint16_t port, std::initializer_list<csp::net::protocol_option>)`
+   entry point. Each `enable()` factory lives in its own protocol TU and
+   returns an opaque `protocol_option` (a `void* config` + a function-
+   pointer `apply` + an optional `destroy`). The unified `serve` walks the
+   option list and calls each `apply()`; each apply starts its protocol's
+   server (delegating to the existing direct-call API) and pushes the
+   typed server handle into the returned
+   `csp::net::server::protocol_servers` (a `std::vector<std::any>`).
+   Critically: the unified `serve` lives in `dist/csp.cpp` (the front-door
+   TU) and references no protocol symbols by name — only via the type-
+   erased function pointers carried in the `protocol_option`s.
+
+   Phase B ships in a minimum-viable shape: single-protocol case (e.g.
+   `csp::net::serve(8080, {csp::http::enable()})`) is fully wired. The
+   only protocol with a non-stub `enable()` in the initial drop is
+   `csp::http`; other protocols' factories will land as they're wired
+   through. ALPN negotiation across multiple options (TLS + ALPN
+   choosing between HTTP/1.1 and HTTP/2 on the same socket) is the
+   most consequential follow-up — it requires the TLS option's apply
+   to install an ALPN callback that consults the other applied options'
+   advertised protocol names, which is more careful than apply() running
+   in isolation. Filed for the design pass when a real user pulls.
 
 The reason for splitting Phase A and Phase B: the file split is mechanical
 and unblocks downstream users immediately. The unified-server API needs more

--- a/docs/design/per-protocol-dist.md
+++ b/docs/design/per-protocol-dist.md
@@ -196,9 +196,15 @@ This rule is the easiest to violate accidentally. We enforce it by:
 1. The amalgamation script excludes protocol .cc files from `dist/csp.cpp` —
    any new file added under `src/` that wants TLS or HTTP must be either
    gated into a per-protocol .cpp or excluded from the front-door TU.
-2. A grep-based lint (planned, see follow-up sub-target) scans `dist/csp.cpp`
-   for `csp::tls::`, `csp::http::`, `csp::http2::`, etc. — non-zero hits fail
-   the build.
+2. [`scripts/lint_frontdoor.py`](../../scripts/lint_frontdoor.py) (🎯T23.4)
+   greps `dist/csp.cpp` and every `src/` file that amalgamates into it for
+   `csp::tls::`, `csp::http::`, `csp::http2::`, `csp::http3::`, `csp::ws::`,
+   `csp::quic::` references. The lint strips comments before scanning so
+   docstrings referencing a protocol API don't trip it. Wired into `make`
+   (every build runs the lint; failure aborts the build with a message
+   naming the violated rule) and into `make bullseye` (the standing-
+   invariants check). Catches violations at source-edit time, not at
+   `make dist` time.
 
 ### Forward-looking factory API: `csp::<proto>::enable()`
 

--- a/include/csp/http.h
+++ b/include/csp/http.h
@@ -114,6 +114,20 @@ struct server {
 server serve(uint16_t port, serve_options opts = {});
 server serve(const std::string& addr, uint16_t port, serve_options opts = {});
 
+// --- Factory for csp::net::serve (🎯T23.1) ---
+//
+// Returns a `csp::net::protocol_option` that, when passed to
+// `csp::net::serve(port, {...})`, starts an HTTP/1.1 server on that port
+// and stashes the resulting `csp::http::server` in
+// `csp::net::server::protocol_servers` (retrievable with
+// `std::any_cast<csp::http::server&>`).
+//
+// Calling this factory is what keeps `csp_http.cpp` and llhttp live in
+// the link; a build that doesn't reference `csp::http::enable()` (and
+// doesn't call `csp::http::serve` directly) drops both via `-dead_strip`
+// / `--gc-sections`.
+csp::net::protocol_option enable(serve_options opts = {});
+
 // --- Client ---
 
 struct fetch_options {

--- a/include/csp/net.h
+++ b/include/csp/net.h
@@ -4,9 +4,12 @@
 #include <csp/io.h>
 #include <csp/part/io.h>
 
+#include <any>
 #include <cstdint>
+#include <initializer_list>
 #include <string>
 #include <utility>
+#include <vector>
 
 namespace csp::net {
 
@@ -59,5 +62,58 @@ listener listen(const std::string& addr, uint16_t port,
 
 connection dial(const std::string& host, uint16_t port);
 connection dial(const std::string& host, const std::string& service);
+
+// --- Unified server entry point (🎯T23.1) ------------------------------
+//
+// `csp::net::serve(port, {tls::enable(...), http::enable(), ...})` starts
+// a server on `port` running the per-protocol stacks named in the option
+// list. The option list is built from per-protocol `enable()` factories
+// living in their own drop-in .cpp files — calling, e.g., `http::enable()`
+// is what keeps `csp_http.cpp` (and llhttp) live in the link; an enable()
+// that's not called leaves its protocol TU dead and the third-party
+// library it depends on dropped by `-dead_strip` / `--gc-sections`.
+//
+// The opaque `protocol_option` struct carries an `apply()` function pointer
+// — the only mechanism the front-door TU (`csp.cpp`) uses to invoke
+// per-protocol behaviour — so Rule 5 of the per-protocol DCE model holds
+// (docs/design/per-protocol-dist.md §5).
+//
+// Phase B (initial release): single-protocol case fully supported. ALPN
+// negotiation for `tls` + `{http, http2}` and the interaction between
+// multiple option types is follow-up work — see 🎯T23.1's context for
+// the design space.
+
+struct server;
+
+// Context handed to each `protocol_option::apply()`. Apply functions stash
+// their per-protocol server handles into `out->protocol_servers` (typed,
+// retrievable via `std::any_cast`).
+struct apply_context {
+    uint16_t port;       // port the user asked for
+    server*  out;        // destination for the protocol-specific server handles
+};
+
+// Opaque option produced by `csp::<proto>::enable()` factories. The
+// front-door TU references only the `apply` function pointer — never the
+// protocol's namespace by name — which keeps Rule 5 intact.
+struct protocol_option {
+    void* config = nullptr;
+    void (*apply)(apply_context&, void* config) = nullptr;
+    void (*destroy)(void* config) = nullptr;   // nullptr = no cleanup
+};
+
+// Unified server handle. Holds typed protocol-server objects (each
+// protocol's `serve()` return type) inside a `std::any` so the front-
+// door TU stays protocol-agnostic. Callers cast back with `std::any_cast`:
+//
+//     auto srv = csp::net::serve(8080, {csp::http::enable()});
+//     auto& http_srv = std::any_cast<csp::http::server&>(srv.protocol_servers[0]);
+//
+struct server {
+    uint16_t              port;
+    std::vector<std::any> protocol_servers;
+};
+
+server serve(uint16_t port, std::initializer_list<protocol_option> opts);
 
 } // namespace csp::net

--- a/scripts/lint_frontdoor.py
+++ b/scripts/lint_frontdoor.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Lint the front-door TU and its amalgamated source files for protocol-
+specific namespace references.
+
+Rule 5 of the per-protocol DCE model (docs/design/per-protocol-dist.md §5):
+
+    The front-door TU (dist/csp.cpp) references no protocol-specific symbols.
+
+Concretely: no `csp::tls::`, `csp::http::`, `csp::http2::`, `csp::http3::`,
+`csp::ws::`, or `csp::quic::` symbol references in dist/csp.cpp or in any
+of the src/*.cc / src/*.cpp files that scripts/amalgamate.py folds into it.
+
+If you need to glue protocol behaviour into shared code, do it through the
+per-protocol enable() factory mechanism (csp_net.h) — the front-door TU
+sees only an opaque protocol_option struct and a function-pointer apply(),
+which leaves no name-level reference for the linker to keep the protocol
+TU alive against.
+
+Exit codes: 0 = clean, 1 = violations found, 2 = setup error.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC_DIR = REPO_ROOT / 'src'
+DIST_FILE = REPO_ROOT / 'dist' / 'csp.cpp'
+
+# Source files that amalgamate.py folds into dist/csp.cpp. Must match the
+# `excluded_sources` logic in scripts/amalgamate.py — everything in src/
+# except csp_globals.cpp and the per-protocol implementations.
+PROTOCOL_SRC_NAMES = {'tls.cc', 'http.cc', 'http2.cc', 'ws.cc', 'quic.cc', 'http3.cc'}
+GLOBALS_SRC_NAME = 'csp_globals.cpp'
+
+PROTOCOLS = ('tls', 'http', 'http2', 'http3', 'ws', 'quic')
+PATTERN = re.compile(r'\bcsp::(' + '|'.join(PROTOCOLS) + r')::')
+
+# Strip // line comments and /* … */ block comments (including multi-line)
+# before scanning. Avoids false positives from code comments that legitimately
+# reference protocol APIs ("see csp::http::serve() for details" etc.).
+COMMENT_RE = re.compile(r'//[^\n]*|/\*.*?\*/', re.DOTALL)
+
+
+def amalgamated_sources() -> list[Path]:
+    """Source files that fold into dist/csp.cpp."""
+    if not SRC_DIR.is_dir():
+        sys.stderr.write(f'lint_frontdoor: src/ not found at {SRC_DIR}\n')
+        sys.exit(2)
+    excluded = PROTOCOL_SRC_NAMES | {GLOBALS_SRC_NAME}
+    return sorted(
+        p for p in list(SRC_DIR.glob('*.cc')) + list(SRC_DIR.glob('*.cpp'))
+        if p.name not in excluded
+    )
+
+
+def scan(path: Path) -> list[tuple[int, str]]:
+    """Return list of (line_no, line_text) where PATTERN matches in `path`,
+    after stripping comments."""
+    text = path.read_text(encoding='utf-8', errors='replace')
+    stripped = COMMENT_RE.sub(lambda m: '\n' * m.group(0).count('\n'), text)
+    hits: list[tuple[int, str]] = []
+    for n, line in enumerate(stripped.splitlines(), start=1):
+        if PATTERN.search(line):
+            hits.append((n, line.rstrip()))
+    return hits
+
+
+def main() -> int:
+    targets = amalgamated_sources()
+    if DIST_FILE.exists():
+        targets.append(DIST_FILE)
+    elif not targets:
+        sys.stderr.write('lint_frontdoor: nothing to check\n')
+        return 2
+
+    violations: list[tuple[Path, int, str]] = []
+    for path in targets:
+        for ln, text in scan(path):
+            violations.append((path, ln, text))
+
+    if not violations:
+        return 0
+
+    for path, ln, text in violations:
+        rel = path.relative_to(REPO_ROOT)
+        print(f'{rel}:{ln}: {text}', file=sys.stderr)
+    print('', file=sys.stderr)
+    print('Rule 5 violated: the front-door TU (dist/csp.cpp) must not reference',
+          file=sys.stderr)
+    print('any csp::<proto>:: symbol. See docs/design/per-protocol-dist.md §5.',
+          file=sys.stderr)
+    print('Glue protocol behaviour through the csp::net::serve(opts) +',
+          file=sys.stderr)
+    print('csp::<proto>::enable() factory mechanism instead.', file=sys.stderr)
+    return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/subset_check.sh
+++ b/scripts/subset_check.sh
@@ -259,6 +259,7 @@ cxx_flags=(-std=c++20 -stdlib=libc++ -O2
            "${DEFINES[@]}"
            "${INCLUDES[@]}")
 cc_flags=(-O2 -ffunction-sections -fdata-sections
+          "${DEFINES[@]}"
           "${INCLUDES[@]}")
 
 cpp_objs=()

--- a/scripts/subset_check.sh
+++ b/scripts/subset_check.sh
@@ -1,0 +1,336 @@
+#!/usr/bin/env bash
+# subset_check.sh — verify the per-protocol drop-in's linker dead-code
+# elimination works as advertised. Fetches the third-party libraries for
+# a subset configuration, compiles dist + the subset sample, links, and
+# uses `nm` to confirm that libraries belonging to unselected protocols
+# do NOT contribute any symbols to the final binary. Implements 🎯T23.3.
+#
+# Usage: scripts/subset_check.sh <subset> [<work-dir>]
+#
+# Subsets:
+#   channels   — csp.cpp + csp_globals.cpp only; no third-party libs.
+#   http       — + csp_http.cpp + llhttp.
+#   http+ws    — + csp_ws.cpp + wslay (transitively pulls http via the
+#                upgrade flow).
+#   quic       — + csp_quic.cpp + csp_tls.cpp + ngtcp2 + picotls.
+#   full       — every drop-in + every library.
+#
+# work-dir defaults to a fresh tempdir; CI passes one to keep ccache warm
+# across matrix jobs.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+SUBSET="${1:-}"
+WORK_DIR="${2:-$(mktemp -d -t subset-check.XXXXXX)}"
+
+# Compiler overrides. CI's Linux matrix uses clang-18 for libc++ support;
+# macOS uses the system clang. Source builds use `cc`/`c++` by default.
+CXX_BIN="${CXX:-c++}"
+CC_BIN="${CC:-cc}"
+
+case "$(uname -s)" in
+    Darwin) DEAD_STRIP_FLAG="-Wl,-dead_strip" ;;
+    Linux)  DEAD_STRIP_FLAG="-Wl,--gc-sections" ;;
+    *)      echo "subset_check: unsupported OS $(uname -s)" >&2; exit 2 ;;
+esac
+
+# Symbol prefixes by library. Each matches an optional leading underscore
+# so the same regex works on macOS (Mach-O prefixes C symbols with `_`)
+# and Linux (ELF doesn't).
+SYM_LLHTTP='^_?llhttp_'
+SYM_NGHTTP2='^_?nghttp2_'
+SYM_NGHTTP3='^_?nghttp3_'
+SYM_NGTCP2='^_?ngtcp2_'
+SYM_WSLAY='^_?wslay_'
+SYM_PICOTLS='^_?ptls_'
+
+# Curated picotls minicrypto source list — mirrors CSP's project Makefile
+# PICOTLS_SRCS. picotls/lib/ also contains mbedtls.c, openssl.c, fusion.c,
+# etc., which require backends we don't link — globbing breaks the build.
+picotls_srcs() {
+    local d="$1"
+    printf '%s\n' \
+        "$d/picotls/lib/picotls.c" \
+        "$d/picotls/lib/hpke.c" \
+        "$d/picotls/lib/pembase64.c" \
+        "$d/picotls/lib/cifra.c" \
+        "$d/picotls/lib/cifra/x25519.c" \
+        "$d/picotls/lib/cifra/chacha20.c" \
+        "$d/picotls/lib/cifra/aes128.c" \
+        "$d/picotls/lib/cifra/aes256.c" \
+        "$d/picotls/lib/cifra/random.c" \
+        "$d/picotls/lib/uecc.c" \
+        "$d/picotls/lib/minicrypto-pem.c" \
+        "$d/picotls/lib/asn1.c" \
+        "$d/picotls/lib/ffx.c" \
+        "$d/picotls/deps/micro-ecc/uECC.c" \
+        "$d/picotls/deps/cifra/src/aes.c" \
+        "$d/picotls/deps/cifra/src/blockwise.c" \
+        "$d/picotls/deps/cifra/src/chacha20.c" \
+        "$d/picotls/deps/cifra/src/chash.c" \
+        "$d/picotls/deps/cifra/src/curve25519.c" \
+        "$d/picotls/deps/cifra/src/drbg.c" \
+        "$d/picotls/deps/cifra/src/hmac.c" \
+        "$d/picotls/deps/cifra/src/gcm.c" \
+        "$d/picotls/deps/cifra/src/gf128.c" \
+        "$d/picotls/deps/cifra/src/modes.c" \
+        "$d/picotls/deps/cifra/src/poly1305.c" \
+        "$d/picotls/deps/cifra/src/sha256.c" \
+        "$d/picotls/deps/cifra/src/sha512.c"
+}
+
+llhttp_srcs() {
+    local d="$1"
+    printf '%s\n' \
+        "$d/llhttp/src/llhttp.c" \
+        "$d/llhttp/src/api.c" \
+        "$d/llhttp/src/http.c"
+}
+
+wslay_srcs() {
+    local d="$1"
+    printf '%s\n' \
+        "$d/wslay/lib/wslay_frame.c" \
+        "$d/wslay/lib/wslay_event.c" \
+        "$d/wslay/lib/wslay_queue.c" \
+        "$d/wslay/lib/wslay_net.c"
+}
+
+# --- per-subset configuration ----------------------------------------
+
+DROPIN_CORE=(csp.cpp csp_globals.cpp)
+DROPIN_PROTO=()
+VENDOR_FLAGS=()
+DEFINES=()
+INCLUDES=()
+EXPECTED_PRESENT=()
+EXPECTED_ABSENT=()
+
+case "$SUBSET" in
+    channels)
+        EXPECTED_ABSENT=("$SYM_LLHTTP" "$SYM_NGHTTP2" "$SYM_NGHTTP3" "$SYM_NGTCP2" "$SYM_WSLAY" "$SYM_PICOTLS")
+        ;;
+    http)
+        DROPIN_PROTO+=(csp_http.cpp)
+        VENDOR_FLAGS+=(--http)
+        DEFINES+=(-DSUBSET_HTTP)
+        INCLUDES+=(-I "$WORK_DIR/vendor/llhttp/include")
+        EXPECTED_PRESENT=("$SYM_LLHTTP")
+        EXPECTED_ABSENT=("$SYM_NGHTTP2" "$SYM_NGHTTP3" "$SYM_NGTCP2" "$SYM_WSLAY" "$SYM_PICOTLS")
+        ;;
+    http+ws)
+        DROPIN_PROTO+=(csp_http.cpp csp_ws.cpp)
+        VENDOR_FLAGS+=(--http --ws)
+        DEFINES+=(-DSUBSET_HTTP -DSUBSET_WS -DHAVE_ARPA_INET_H -DHAVE_NETINET_IN_H)
+        INCLUDES+=(
+            -I "$WORK_DIR/vendor/llhttp/include"
+            -I "$WORK_DIR/vendor/wslay/lib/includes"
+            -I "$WORK_DIR/vendor/wslay/lib"
+        )
+        EXPECTED_PRESENT=("$SYM_LLHTTP" "$SYM_WSLAY")
+        EXPECTED_ABSENT=("$SYM_NGHTTP2" "$SYM_NGHTTP3" "$SYM_NGTCP2" "$SYM_PICOTLS")
+        ;;
+    quic)
+        DROPIN_PROTO+=(csp_tls.cpp csp_quic.cpp)
+        VENDOR_FLAGS+=(--quic)
+        DEFINES+=(-DCSP_TLS -DSUBSET_QUIC)
+        INCLUDES+=(
+            -I "$WORK_DIR/vendor/picotls/include"
+            -I "$WORK_DIR/vendor/picotls/deps/cifra/src"
+            -I "$WORK_DIR/vendor/picotls/deps/cifra/src/ext"
+            -I "$WORK_DIR/vendor/picotls/deps/micro-ecc"
+            -I "$WORK_DIR/vendor/ngtcp2/lib/includes"
+            -I "$WORK_DIR/vendor/ngtcp2/crypto/includes"
+            -I "$WORK_DIR/vendor/ngtcp2/lib"
+            -I "$WORK_DIR/vendor/ngtcp2/crypto"
+        )
+        EXPECTED_PRESENT=("$SYM_NGTCP2" "$SYM_PICOTLS")
+        EXPECTED_ABSENT=("$SYM_LLHTTP" "$SYM_NGHTTP2" "$SYM_NGHTTP3" "$SYM_WSLAY")
+        ;;
+    full)
+        DROPIN_PROTO+=(csp_tls.cpp csp_http.cpp csp_http2.cpp csp_ws.cpp csp_quic.cpp csp_http3.cpp)
+        VENDOR_FLAGS+=(--all)
+        # NB: SUBSET_HTTP3 *would* keep nghttp3 alive via &csp::http3::serve,
+        # except http3::serve is currently a stub (T3.9, blocked on T3.8
+        # QUIC transport). nghttp3 still gets compiled into the build, but
+        # dead-strip removes it — correctly — because nothing live references
+        # nghttp3 symbols. When T3.9 lands, the SUBSET_HTTP3 reference plus
+        # nghttp3 to EXPECTED_PRESENT below.
+        DEFINES+=(-DCSP_TLS -DSUBSET_HTTP -DSUBSET_HTTP2 -DSUBSET_HTTP3
+                  -DSUBSET_WS -DSUBSET_QUIC
+                  -DHAVE_ARPA_INET_H -DHAVE_NETINET_IN_H
+                  -DBUILDING_NGHTTP2 -DBUILDING_NGHTTP3)
+        INCLUDES+=(
+            -I "$WORK_DIR/vendor/llhttp/include"
+            -I "$WORK_DIR/vendor/picotls/include"
+            -I "$WORK_DIR/vendor/picotls/deps/cifra/src"
+            -I "$WORK_DIR/vendor/picotls/deps/cifra/src/ext"
+            -I "$WORK_DIR/vendor/picotls/deps/micro-ecc"
+            -I "$WORK_DIR/vendor/nghttp2/lib/includes"
+            -I "$WORK_DIR/vendor/nghttp3/lib/includes"
+            -I "$WORK_DIR/vendor/nghttp3/lib"
+            -I "$WORK_DIR/vendor/ngtcp2/lib/includes"
+            -I "$WORK_DIR/vendor/ngtcp2/crypto/includes"
+            -I "$WORK_DIR/vendor/ngtcp2/lib"
+            -I "$WORK_DIR/vendor/ngtcp2/crypto"
+            -I "$WORK_DIR/vendor/wslay/lib/includes"
+            -I "$WORK_DIR/vendor/wslay/lib"
+        )
+        EXPECTED_PRESENT=("$SYM_LLHTTP" "$SYM_NGHTTP2" "$SYM_NGTCP2" "$SYM_WSLAY" "$SYM_PICOTLS")
+        ;;
+    *)
+        echo "subset_check: unknown subset '$SUBSET'" >&2
+        echo "  expected one of: channels, http, http+ws, quic, full" >&2
+        exit 2
+        ;;
+esac
+
+echo "=== subset_check: subset=$SUBSET, work_dir=$WORK_DIR ==="
+
+# --- stage the dist drop-in into the work dir -----------------------
+
+mkdir -p "$WORK_DIR/dist" "$WORK_DIR/scripts" "$WORK_DIR/test"
+cp -R "$REPO_ROOT/dist/." "$WORK_DIR/dist/"
+cp "$REPO_ROOT/scripts/vendor-deps.sh" "$WORK_DIR/scripts/"
+cp "$REPO_ROOT/test/dist_subset_sample.cc" "$WORK_DIR/test/"
+
+# --- fetch vendor libs ----------------------------------------------
+
+if (( ${#VENDOR_FLAGS[@]} > 0 )); then
+    ( cd "$WORK_DIR" && ./scripts/vendor-deps.sh "${VENDOR_FLAGS[@]}" )
+fi
+
+# --- assemble third-party .c source list (after fetch) --------------
+
+C_SRCS=()
+add_srcs() {
+    local f
+    while IFS= read -r f; do
+        if [[ -f "$f" ]]; then
+            C_SRCS+=("$f")
+        else
+            echo "  WARN: expected source missing: $f" >&2
+        fi
+    done
+}
+
+case "$SUBSET" in
+    http)
+        add_srcs < <(llhttp_srcs "$WORK_DIR/vendor")
+        ;;
+    http+ws)
+        add_srcs < <(llhttp_srcs "$WORK_DIR/vendor")
+        add_srcs < <(wslay_srcs "$WORK_DIR/vendor")
+        ;;
+    quic)
+        add_srcs < <(picotls_srcs "$WORK_DIR/vendor")
+        for f in "$WORK_DIR/vendor/ngtcp2/lib"/ngtcp2_*.c "$WORK_DIR/vendor/ngtcp2/crypto/shared.c"; do
+            C_SRCS+=("$f")
+        done
+        C_SRCS+=("$WORK_DIR/dist/ngtcp2_crypto_picotls_minicrypto.c")
+        ;;
+    full)
+        add_srcs < <(llhttp_srcs "$WORK_DIR/vendor")
+        add_srcs < <(picotls_srcs "$WORK_DIR/vendor")
+        add_srcs < <(wslay_srcs "$WORK_DIR/vendor")
+        for f in "$WORK_DIR/vendor/nghttp2/lib"/nghttp2_*.c "$WORK_DIR/vendor/nghttp2/lib/sfparse.c"; do
+            C_SRCS+=("$f")
+        done
+        for f in "$WORK_DIR/vendor/nghttp3/lib"/nghttp3_*.c; do
+            C_SRCS+=("$f")
+        done
+        for f in "$WORK_DIR/vendor/ngtcp2/lib"/ngtcp2_*.c "$WORK_DIR/vendor/ngtcp2/crypto/shared.c"; do
+            C_SRCS+=("$f")
+        done
+        C_SRCS+=("$WORK_DIR/dist/ngtcp2_crypto_picotls_minicrypto.c")
+        ;;
+esac
+
+# --- compile + link the sample --------------------------------------
+
+cd "$WORK_DIR"
+
+cxx_flags=(-std=c++20 -stdlib=libc++ -O2
+           -ffunction-sections -fdata-sections
+           -Wno-unused-function -Wno-deprecated-declarations
+           -I dist
+           "${DEFINES[@]}"
+           "${INCLUDES[@]}")
+cc_flags=(-O2 -ffunction-sections -fdata-sections
+          "${INCLUDES[@]}")
+
+cpp_objs=()
+for src in "${DROPIN_CORE[@]}" "${DROPIN_PROTO[@]}"; do
+    out="${src%.cpp}.o"
+    echo "  cxx $src"
+    "$CXX_BIN" "${cxx_flags[@]}" -c "dist/$src" -o "$out"
+    cpp_objs+=("$out")
+done
+
+echo "  cxx test/dist_subset_sample.cc"
+"$CXX_BIN" "${cxx_flags[@]}" -c test/dist_subset_sample.cc -o sample.o
+
+echo "  (${#C_SRCS[@]} vendored .c files to compile)"
+c_objs=()
+i=0
+for src in "${C_SRCS[@]}"; do
+    out="vlib_${i}.o"
+    if ! "$CC_BIN" "${cc_flags[@]}" -c "$src" -o "$out" 2> "vlib_${i}.log"; then
+        echo "  FAIL compiling $src" >&2
+        sed -n '1,20p' "vlib_${i}.log" >&2
+        exit 1
+    fi
+    c_objs+=("$out")
+    i=$((i+1))
+done
+
+echo "  link"
+"$CXX_BIN" -std=c++20 -stdlib=libc++ "$DEAD_STRIP_FLAG" \
+    sample.o "${cpp_objs[@]}" "${c_objs[@]}" -o sample
+
+# --- verify symbol presence/absence --------------------------------
+
+echo
+echo "=== verifying symbols ==="
+
+# `nm -P | awk ...` extracts defined-symbol names. We pipe through awk
+# (not into a here-string at this step) because nm output is unbounded;
+# the result is bounded so storing it in a variable is fine for the
+# verification loop below.
+SYMS=$(nm -P sample 2>/dev/null | awk '$2 != "U" { print $1 }')
+
+# Use here-strings (`grep ... <<< "$SYMS"`) for the per-prefix checks
+# below — piping `echo "$SYMS" | grep -q` causes early-exit grep to
+# SIGPIPE the upstream `echo`, which `pipefail` then propagates as a
+# pipeline failure, making the if-condition spuriously NO-match.
+
+fail=0
+for prefix in "${EXPECTED_PRESENT[@]}"; do
+    if grep -qE "$prefix" <<< "$SYMS"; then
+        echo "  ✓ present: $prefix"
+    else
+        echo "  ✗ MISSING (should be present): $prefix" >&2
+        fail=1
+    fi
+done
+for prefix in "${EXPECTED_ABSENT[@]}"; do
+    if grep -qE "$prefix" <<< "$SYMS"; then
+        offenders=$(grep -E "$prefix" <<< "$SYMS" | head -5)
+        echo "  ✗ LEAKED (should be absent): $prefix" >&2
+        sed 's/^/      /' <<< "$offenders" >&2
+        fail=1
+    else
+        echo "  ✓ absent:  $prefix"
+    fi
+done
+
+if (( fail )); then
+    echo
+    echo "subset_check FAILED for subset=$SUBSET" >&2
+    exit 1
+fi
+
+echo
+echo "subset_check: subset=$SUBSET — all symbol expectations met."

--- a/src/http.cc
+++ b/src/http.cc
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <atomic>
 #include <cctype>
+#include <memory>
 #include <sstream>
 #include <string>
 
@@ -782,6 +783,37 @@ response fetch(
         state.status_code,
         std::move(state.headers),
         std::move(state.body)};
+}
+
+// --- Factory for csp::net::serve (🎯T23.1) ---
+//
+// The `apply()` lambda lives in this TU (csp_http.cpp in the dist drop-in),
+// so referencing `csp::http::enable()` from user code pulls the entire TU
+// — including its llhttp_* references — into the link. The front-door TU
+// (csp.cpp) reaches enable() only through the function-pointer-shaped
+// `protocol_option`, which leaves Rule 5 (no protocol symbols in the front
+// door) intact.
+
+csp::net::protocol_option enable(serve_options opts) {
+    auto* cfg = new serve_options(std::move(opts));
+    return csp::net::protocol_option{
+        .config = cfg,
+        .apply = [](csp::net::apply_context& ctx, void* config) {
+            auto* c = static_cast<serve_options*>(config);
+            // Start a real HTTP/1.1 server and hand its handle to the
+            // unified net::server. csp::http::server is move-only (its
+            // endpoints reader can't be copied), so we wrap it in a
+            // shared_ptr to fit std::any's copyable requirement. Callers
+            // retrieve the typed handle via
+            // std::any_cast<std::shared_ptr<csp::http::server>>(s.protocol_servers[0]).
+            ctx.out->protocol_servers.emplace_back(
+                std::make_shared<csp::http::server>(
+                    csp::http::serve(ctx.port, *c)));
+        },
+        .destroy = [](void* config) {
+            delete static_cast<serve_options*>(config);
+        },
+    };
 }
 
 } // namespace csp::http

--- a/src/net.cc
+++ b/src/net.cc
@@ -230,4 +230,28 @@ connection dial(const std::string& host, const std::string& service) {
     throw csp::error("dial failed: all addresses exhausted");
 }
 
+// --- Unified server (🎯T23.1) -----------------------------------------
+//
+// Walks the option list, calling each `apply()` so the protocol can stash
+// its server handle into `out.protocol_servers`. The front-door TU never
+// references any `csp::<proto>::` symbol by name — every per-protocol
+// behaviour is reached through the function pointer in `protocol_option`.
+// That keeps Rule 5 of the per-protocol DCE model intact: an `enable()`
+// the user never calls leaves its protocol TU dead, and the linker drops
+// the third-party libraries that protocol depended on.
+
+server serve(uint16_t port, std::initializer_list<protocol_option> opts) {
+    server out{.port = port, .protocol_servers = {}};
+    apply_context ctx{.port = port, .out = &out};
+    for (const auto& opt : opts) {
+        if (opt.apply != nullptr) {
+            opt.apply(ctx, opt.config);
+        }
+        if (opt.destroy != nullptr) {
+            opt.destroy(opt.config);
+        }
+    }
+    return out;
+}
+
 } // namespace csp::net

--- a/test/dist_subset_sample.cc
+++ b/test/dist_subset_sample.cc
@@ -1,0 +1,64 @@
+// Subset-link sample exercised by scripts/subset_check.sh (🎯T23.3).
+// Each protocol referenced here keeps that protocol's drop-in TU alive
+// through the linker; protocols not referenced should be dropped via
+// -ffunction-sections + -Wl,-dead_strip / --gc-sections. The companion
+// script links this with the appropriate subset of csp_<proto>.cpp drop-in
+// files and uses `nm` to verify that unselected protocols' third-party
+// library symbols are absent from the final binary.
+
+#include "csp.h"
+
+#include <cstdio>
+
+// Volatile global keeps the optimiser from folding away the address-takes
+// below; the linker treats the right-hand side as a live reference.
+namespace { void* volatile sink = nullptr; }
+
+int main() {
+    // Channels always work — they're in the core TU and don't depend on
+    // any third-party library. The compile-time gates below add protocol
+    // symbol references for each subset under test.
+    csp::run([] {
+        auto [w, r] = csp::chan<int>{};
+        csp::spawn([o = std::move(w)] mutable { o << 42; });
+        (void)r.read();
+    });
+
+    // Force-take addresses of protocol entry points. Assigning each
+    // function pointer to the volatile `sink` above keeps the optimiser
+    // from folding the address away; the linker then treats each
+    // assignment's right-hand side as a live reference, which pulls in
+    // the entire transitive symbol set (csp_<proto>.cpp → its third-
+    // party library).
+
+#ifdef SUBSET_HTTP
+    sink = reinterpret_cast<void*>(
+        static_cast<csp::http::server (*)(uint16_t, csp::http::serve_options)>(
+            &csp::http::serve));
+#endif
+
+#ifdef SUBSET_WS
+    sink = reinterpret_cast<void*>(&csp::ws::upgrade);
+#endif
+
+#ifdef SUBSET_QUIC
+    sink = reinterpret_cast<void*>(
+        static_cast<csp::quic::listener (*)(uint16_t, csp::quic::listen_options)>(
+            &csp::quic::listen));
+#endif
+
+#ifdef SUBSET_HTTP2
+    sink = reinterpret_cast<void*>(
+        static_cast<csp::http2::server (*)(uint16_t, csp::http2::serve_options)>(
+            &csp::http2::serve));
+#endif
+
+#ifdef SUBSET_HTTP3
+    sink = reinterpret_cast<void*>(
+        static_cast<csp::http3::server (*)(uint16_t, csp::http3::serve_options)>(
+            &csp::http3::serve));
+#endif
+
+    std::puts("subset sample: OK");
+    return 0;
+}

--- a/test/http.test.cc
+++ b/test/http.test.cc
@@ -12,6 +12,67 @@ using namespace csp;
 
 TEST_SUITE("http") {
 
+// 🎯T23.1 — csp::net::serve(port, {csp::http::enable()}) factory API.
+TEST_CASE("enable---net-serve-with-http-enable") {
+    csp::shutdown_runtime();
+    csp::set_maxprocs(2);
+
+    chan<uint16_t> port_ch;
+
+    spawn([w = std::move(port_ch.w)] {
+        // Unified net::serve walks the option list and starts each
+        // protocol's server. http::enable() apply() calls csp::http::serve
+        // internally and stashes its csp::http::server (wrapped in a
+        // shared_ptr because std::any requires copyable).
+        auto srv = net::serve(0, {http::enable()});
+        REQUIRE(srv.protocol_servers.size() == 1);
+        auto http_srv =
+            std::any_cast<std::shared_ptr<http::server>>(srv.protocol_servers[0]);
+        REQUIRE(http_srv != nullptr);
+        w << http_srv->port;
+
+        http::endpoint ep;
+        if (http_srv->endpoints >> ep) {
+            http::request req;
+            if (ep.requests >> req) {
+                CHECK(req.url == "/factory");
+                std::string body_str = "factory-OK";
+                bytes body(body_str.begin(), body_str.end());
+                req.respond << http::response{
+                    200,
+                    {{"Content-Type", "text/plain"}},
+                    std::move(body)};
+            }
+        }
+    });
+
+    spawn([r = std::move(port_ch.r)] {
+        uint16_t port;
+        r >> port;
+
+        auto conn = net::dial("127.0.0.1", port);
+        std::string req =
+            "GET /factory HTTP/1.1\r\n"
+            "Host: localhost\r\n"
+            "Connection: close\r\n"
+            "\r\n";
+        bytes req_bytes(req.begin(), req.end());
+        conn.output << req_bytes;
+
+        std::string response;
+        bytes chunk;
+        while (conn.input >> chunk) {
+            response.append(chunk.begin(), chunk.end());
+        }
+
+        CHECK(response.find("HTTP/1.1 200 OK") != std::string::npos);
+        CHECK(response.find("factory-OK") != std::string::npos);
+    });
+
+    schedule();
+    csp::shutdown_runtime();
+}
+
 TEST_CASE("serve---basic-get") {
     csp::shutdown_runtime();
     csp::set_maxprocs(2);


### PR DESCRIPTION
## Summary

Phase B of 🎯T23 (per-protocol dist drop-in supports linker dead-code elimination). Phase A landed in v0.15.0 (per-protocol `.cpp` file split + the five DCE rules); Phase B adds the remaining three sub-targets, retiring 🎯T23.

- **🎯T23.4 — Front-door TU lint.** New `scripts/lint_frontdoor.py` greps `dist/csp.cpp` and every `src/` file amalgamated into it for `csp::tls::`, `csp::http::`, `csp::http2::`, `csp::http3::`, `csp::ws::`, `csp::quic::` references (comments stripped first). Wired into the default `make` target and `make bullseye` — every build runs it, violations fail with a Rule-5 named message.
- **🎯T23.3 — CI subset-link matrix.** New `scripts/subset_check.sh` + `test/dist_subset_sample.cc` + `subset-link` GitHub Actions job (5 subsets × 2 OSes = 10 matrix jobs). For each subset (channels / http / http+ws / quic / full) the job runs `vendor-deps.sh`, compiles the dist drop-in + a sample, links with `-dead_strip` / `--gc-sections`, and uses `nm` to assert unselected protocols' library symbol prefixes (`llhttp_`, `nghttp2_`, `nghttp3_`, `ngtcp2_`, `wslay_`, `ptls_`) are absent from the final binary.
- **🎯T23.1 — Factory API.** New `csp::net::protocol_option` + `csp::net::serve(port, opts)` + `csp::http::enable()`. Each per-protocol `enable()` lives in its own drop-in `.cpp`; `csp::net::serve` reaches it only through a function pointer, leaving Rule 5 intact. Phase B ships single-protocol case fully wired (verified end-to-end by a new doctest); ALPN-across-options is the consequential follow-up (documented in `docs/design/per-protocol-dist.md`).

`bullseye.yaml` updates mark 🎯T23.1, 🎯T23.3, 🎯T23.4, and 🎯T23 as achieved.

## Test plan

- [x] `make` — full source build, 744/744 tests pass, lint + md-links clean.
- [x] `make bullseye` — all 5 standing invariants green (build / tests / md-links / lint-frontdoor / clean tree).
- [x] `scripts/lint_frontdoor.py` — clean on tree; trips with Rule-5 message when a violating line is injected into `src/net.cc`.
- [x] `scripts/subset_check.sh` — all 5 subsets pass locally on macOS arm64. http/http+ws/quic each show the expected library symbol present; channels shows everything absent; full has llhttp/nghttp2/ngtcp2/wslay/ptls present (nghttp3 deferred — http3::serve is a stub until 🎯T3.9 lands).
- [x] New doctest `enable---net-serve-with-http-enable` drives a full HTTP/1.1 GET through `csp::net::serve(0, {csp::http::enable()})`.
- [ ] CI matrix (especially the new subset-link jobs on macOS + Linux x86_64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)