### PR TITLE
Release prep for v0.16.0

### DIFF
--- a/dist/csp.h
+++ b/dist/csp.h
@@ -7,9 +7,9 @@
 
 /* csp/csp.h */
 
-#define CSP_VERSION "0.15.0"
+#define CSP_VERSION "0.16.0"
 #define CSP_VERSION_MAJOR 0
-#define CSP_VERSION_MINOR 15
+#define CSP_VERSION_MINOR 16
 #define CSP_VERSION_PATCH 0
 
 

--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#define CSP_VERSION "0.15.0"
+#define CSP_VERSION "0.16.0"
 #define CSP_VERSION_MAJOR 0
-#define CSP_VERSION_MINOR 15
+#define CSP_VERSION_MINOR 16
 #define CSP_VERSION_PATCH 0
 
 #include <csp/internal/log.h>


### PR DESCRIPTION
## Summary

Bump CSP_VERSION macros from 0.15.0 to 0.16.0 and regenerate `dist/csp.h`.

This release bundles five PRs that landed since v0.15.0:

- **#63** — file 🎯T3.10 (walker register provenance) and 🎯T28 (csp-flow SVG hygiene)
- **#64** — 🎯T23.2 `scripts/vendor-deps.sh` for dist drop-in users
- **#65** — 🎯T23 Phase B (factory API + lint + CI subset matrix)
- **#66** — convergence batch closing 🎯T2 / 🎯T5 / 🎯T8 / 🎯T25 / 🎯T26* / 🎯T27 / 🎯T28 and retiring 🎯T11 / 🎯T12 / 🎯T15 / 🎯T16
- **#67** — 🎯T26 narrowed to scheduler wake race via TLA verification; 🎯T14 set aside; Linux build portability fixes (NGHTTP2/NGHTTP3 missing `HAVE_ARPA_INET_H`)

\* 🎯T26 was reopened later in #67 — only the busy-spin symptom was fixed; the Linux-only deadlock remains. See `docs/papers/27-web-crawler-linux-hang.md`.

## Test plan

- [x] `make` green locally (745/745 tests pass)
- [x] `make dist` regenerates without further drift
- [ ] CI green on all platforms
