### PR TITLE
Release prep for v0.17.0

### DIFF
--- a/dist/csp.h
+++ b/dist/csp.h
@@ -7,9 +7,9 @@
 
 /* csp/csp.h */
 
-#define CSP_VERSION "0.16.0"
+#define CSP_VERSION "0.17.0"
 #define CSP_VERSION_MAJOR 0
-#define CSP_VERSION_MINOR 16
+#define CSP_VERSION_MINOR 17
 #define CSP_VERSION_PATCH 0
 
 

--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#define CSP_VERSION "0.16.0"
+#define CSP_VERSION "0.17.0"
 #define CSP_VERSION_MAJOR 0
-#define CSP_VERSION_MINOR 16
+#define CSP_VERSION_MINOR 17
 #define CSP_VERSION_PATCH 0
 
 #include <csp/internal/log.h>


### PR DESCRIPTION
## Summary

Release prep for v0.17.0. Bumps `CSP_VERSION` macros to `0.17.0` and
regenerates `dist/csp.h`.

## Contents of this release

One fix since v0.16.0:

- 🎯T26 Linux web_crawler hang fixed via timer ident tagging in the
  reactor (#69). Timer idents now carry a high sentinel bit
  (`kTimerIdentBit = 1<<63`) so they cannot collide with kernel fd
  numbers in `Reactor::fire_signal` dispatch.

See the release notes for full detail.

## Test plan

- [x] `make` (build + tests + md-links + lint-frontdoor + clean tree)
- [x] `make dist` regenerated cleanly
- [ ] CI green on this PR
