### PR TITLE
Add repo hygiene posture: hygiene.yaml schema + drift validator + fleet aggregator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -514,7 +514,7 @@ BENCH_TARGET := $(BUILDDIR)/csp_bench
 # --- Rules ---
 
 .PHONY: test build bench test-dist check check-tla-tags check-md-links diagrams examples run-examples run-examples-ci dist iwyu clean \
-       docker-test docker-test-arm64 docker-test-x86 docker-image docker-clean bullseye lint-frontdoor
+       docker-test docker-test-arm64 docker-test-x86 docker-image docker-clean bullseye lint-frontdoor hygiene-check
 
 # Explicit default — keep `make` (no args) running the full test suite.
 # Without this, the `bullseye` rule below would become the default target
@@ -711,6 +711,14 @@ TLA_CHECK  := $(filter-out %_Bug.tla,$(TLA_SPECS))
 
 check-tla-tags:
 	@python3 scripts/check_tla_tags.py
+
+# --- Hygiene posture (fleet hygiene initiative) ---
+# Validates hygiene.yaml against repo reality: declared CI jobs / Makefile
+# targets / files / gh settings / scanners must exist; `skipped` items must
+# really be absent; the declared maturity tier must match what's held. Drift
+# fails. Uses `uv run` for the pyyaml dep (system python3 lacks it).
+hygiene-check:
+	@uv run scripts/hygiene_check.py
 
 check: $(TLA_JAR)
 	@fail=0; \

--- a/hygiene.yaml
+++ b/hygiene.yaml
@@ -1,0 +1,436 @@
+# hygiene.yaml — declared, drift-validated hygiene posture for this repo.
+# DRAFT schema (fleet hygiene initiative, piloted in csp). Sibling to
+# bullseye.yaml: bullseye tracks aspirational
+# state ("achieve X"); hygiene tracks steady-state ("we maintain X").
+#
+# Core idea: every item declares INTENT plus a machine-checkable `evidence`
+# pointer. `make hygiene-check` confirms each pointer resolves against repo
+# reality (the CI job exists, the make target exists, the scanner is wired in,
+# the gh setting matches). Drift — a claim with no backing reality, or a
+# skipped item that is silently running — fails the check.
+#
+# Three things distinguish this from a checklist:
+#   1. Negative space is first-class. `state: skipped` items carry a required
+#      `reason`; the validator asserts the thing really is absent (`evidence:
+#      absent:`). A deliberate, reasoned gap is a hygiene STATEMENT.
+#   2. Every item has `cadence` + `enforce`. The validator catches the gap
+#      between "declared blocking" and "actually able to merge past it".
+#   3. Tiers, not a binary. `tier` is the floor this repo GUARANTEES (the
+#      validator derives the highest tier all of whose items pass and asserts
+#      it matches this claim). `aspires` is the bullseye-style target: items
+#      between `tier` and `aspires` are reported as the gap-to-close, not failed.
+
+schema_version: 0
+
+repo: csp
+tier: 2          # held & enforced — every item with tier <= 2 must pass
+aspires: 3       # informational gap target — tier-3 items are reported, not failed
+
+# --- Tier ladder -----------------------------------------------------------
+# Shared vocabulary across the fleet (will move to a global definition the
+# portfolio aggregator reads; inlined here while the schema is being sketched).
+tiers:
+  1: baseline    # LICENSE + README + .gitignore; tests build & run on 1 platform
+  2: maintained  # full platform matrix, examples run, lint+format enforced,
+                 # dist/release discipline, governance settings validated
+  3: hardened    # formal specs checked in CI, security scanning (secret/dep/SAST),
+                 # SBOM + signed releases, fuzzing, perf-regression tracking
+
+# --- evidence: the machine-checkable union (one key per item) --------------
+#   ci_job:     <workflow>#<jobId>            job exists in that workflow
+#   ci_step:    {workflow, name}             a step with that name exists
+#   make_target:<name>                       `make -n <name>` resolves
+#   command:    <argv>                        runs, must exit 0
+#   file:       {path, matches?}             path exists (+ optional regex)
+#   gh_setting: {key, equals}                 `gh api repos/:owner/:repo` matches
+#   scanner:    {tool, config?, invoked?}    config present AND invoked in CI
+#   absent:     <evidence>                    the nested evidence must NOT resolve
+#   manual:     {last_verified}              attestation; no automated backing
+# `state`:   enforced | present | manual | planned | skipped
+# `cadence`: continuous | per-release | periodic:<dur> | once-must-hold
+# `enforce`: blocking | warning | informational
+# `reason`:  free text; REQUIRED when state == skipped or planned.
+
+items:
+
+  # ============================== CORRECTNESS =============================
+  - id: correctness.test-matrix
+    dim: correctness
+    desc: Unit tests run on macOS arm64, Linux x86_64, Linux arm64 (Makefile) + Windows x86_64 (CMake)
+    state: enforced
+    cadence: continuous
+    enforce: blocking
+    tier: 1
+    evidence: {ci_job: ci.yml#test}
+
+  - id: correctness.windows
+    dim: correctness
+    desc: Windows x86_64 builds & tests via CMake, with TLS deliberately off (-DCSP_TLS=OFF)
+    state: enforced
+    cadence: continuous
+    enforce: blocking
+    tier: 2
+    reason: Windows TLS path (picotls) unported; channels/http/ws covered, QUIC+TLS excluded on Windows.
+    evidence: {ci_job: ci.yml#windows}
+
+  - id: correctness.examples-run
+    dim: correctness
+    desc: All example programs compile AND execute (not just compile) in CI
+    state: enforced
+    cadence: continuous
+    enforce: blocking
+    tier: 2
+    evidence: {make_target: run-examples-ci}
+
+  - id: correctness.dist-dropin
+    dim: correctness
+    desc: Amalgamated dist drop-in builds & passes the full test suite
+    state: enforced
+    cadence: continuous
+    enforce: blocking
+    tier: 2
+    evidence: {make_target: test-dist}
+
+  - id: correctness.dist-fresh
+    dim: correctness
+    desc: Committed dist/ is regenerated and asserted byte-identical (no stale amalgamation)
+    state: enforced
+    cadence: continuous
+    enforce: blocking
+    tier: 2
+    evidence: {ci_step: {workflow: ci.yml, name: Check dist is up-to-date}}
+
+  - id: correctness.subset-link-dce
+    dim: correctness
+    desc: Picking a protocol subset (channels/http/http+ws/quic/full) links only that subset's symbols
+    state: enforced
+    cadence: continuous
+    enforce: blocking
+    tier: 3
+    evidence: {ci_job: ci.yml#subset-link}
+
+  - id: correctness.sanitizers-linux
+    dim: correctness
+    desc: ASan+UBSan and TSan run on Linux x86_64 and arm64 against the dist build
+    state: enforced
+    cadence: continuous
+    enforce: blocking
+    tier: 2
+    evidence: {ci_job: ci.yml#sanitize}
+
+  - id: correctness.sanitizers-macos-tsan
+    dim: correctness
+    desc: macOS TSan
+    state: skipped
+    cadence: continuous
+    enforce: informational
+    tier: 3
+    reason: >-
+      50–130× slower than Linux TSan (2–4 h vs 2 min), cancelled ~80% of runs,
+      and has never caught anything Linux arm64/x86_64 TSan didn't. macOS
+      ASan+UBSan is retained.
+    evidence: {absent: {ci_job: "ci.yml#sanitize:macOS TSan"}}
+
+  - id: correctness.formal-tla
+    dim: correctness
+    desc: TLA+ specs of the core concurrency protocols are model-checked in CI
+    state: enforced
+    cadence: continuous
+    enforce: blocking
+    tier: 3
+    evidence: {make_target: check}
+
+  - id: correctness.fuzzing
+    dim: correctness
+    desc: Fuzz harnesses over the wire-protocol parsers (http/ws/quic framing)
+    state: planned
+    cadence: continuous
+    enforce: warning
+    tier: 3
+    reason: Parsers are vendored upstream (llhttp/nghttp2/ngtcp2/wslay) and fuzzed there; no csp-local harness yet.
+    evidence: {absent: {make_target: fuzz}}
+
+  # =========================== SECURITY / SUPPLY ==========================
+  - id: security.secret-scan
+    dim: security
+    desc: Secret scanning (gitleaks) in pre-commit and CI
+    state: planned
+    cadence: continuous
+    enforce: blocking
+    tier: 3
+    reason: No gitleaks config yet; relying on manual review. Highest-priority tier-3 gap.
+    evidence: {absent: {scanner: {tool: gitleaks}}}
+
+  - id: security.dep-vuln-scan
+    dim: security
+    desc: Vulnerability scanning of vendored C deps (osv-scanner over pinned versions)
+    state: planned
+    cadence: periodic:30d
+    enforce: warning
+    tier: 3
+    reason: Deps are vendored & pinned via scripts/vendor-deps.sh; no automated CVE watch on those pins yet.
+    evidence: {absent: {scanner: {tool: osv-scanner}}}
+
+  - id: security.sast
+    dim: security
+    desc: Static application security testing (CodeQL C/C++)
+    state: planned
+    cadence: continuous
+    enforce: warning
+    tier: 3
+    reason: Not yet enabled; clang sanitizers + TLA+ cover the concurrency core but not injection/overflow classes.
+    evidence: {absent: {ci_job: ci.yml#codeql}}
+
+  - id: security.dep-pinning
+    dim: security
+    desc: All third-party C libraries vendored at pinned versions via a reproducible script
+    state: present
+    cadence: per-release
+    enforce: warning
+    tier: 2
+    evidence: {file: {path: scripts/vendor-deps.sh}}
+
+  - id: security.actions-perms
+    dim: security
+    desc: GitHub Actions default token permissions are read-only (least privilege)
+    state: planned
+    cadence: once-must-hold
+    enforce: warning
+    tier: 3
+    reason: No top-level `permissions:` block in ci.yml yet; inherits repo default.
+    evidence: {absent: {ci_step: {workflow: ci.yml, name: permissions}}}
+
+  # ============================== CODE QUALITY ============================
+  - id: quality.frontdoor-lint
+    dim: quality
+    desc: Public header surface is linted (lint_frontdoor.py — no leaked internals)
+    state: enforced
+    cadence: continuous
+    enforce: blocking
+    tier: 2
+    evidence: {make_target: lint-frontdoor}
+
+  - id: quality.iwyu
+    dim: quality
+    desc: include-what-you-use audit over the dist build
+    state: present
+    cadence: periodic:release
+    enforce: informational
+    tier: 2
+    evidence: {make_target: iwyu}
+
+  - id: quality.format
+    dim: quality
+    desc: Sources are clang-format clean, enforced in CI
+    state: planned
+    cadence: continuous
+    enforce: warning
+    tier: 2
+    reason: >-
+      No .clang-format committed; formatting is by-hand convention, guarded by
+      lint-frontdoor + iwyu rather than a formatter. Warning, not blocking —
+      can't block on a formatter the repo doesn't run. Gap to close if adopted.
+    evidence: {absent: {file: {path: .clang-format}}}
+
+  # =========================== DEPENDENCY HEALTH ==========================
+  - id: deps.vendor-freshness
+    dim: deps
+    desc: Vendored upstreams (llhttp/nghttp2/ngtcp2/wslay/picotls) reviewed against latest each release
+    state: manual
+    cadence: per-release
+    enforce: informational
+    tier: 2
+    evidence: {manual: {last_verified: 2026-05-21}}
+
+  # ========================== RELEASE & VERSIONING =======================
+  - id: release.semver-minor
+    dim: release
+    desc: Releases bump MINOR only; CSP_VERSION constant matches the latest git tag
+    state: enforced
+    cadence: per-release
+    enforce: blocking
+    tier: 2
+    evidence:
+      command: >-
+        test "$(grep -oE 'CSP_VERSION "[0-9.]+"' include/csp/csp.h | grep -oE '[0-9.]+')"
+        = "$(git describe --tags --abbrev=0 | tr -d v)"
+
+  - id: release.changelog
+    dim: release
+    desc: A maintained CHANGELOG records user-visible changes per release
+    state: planned
+    cadence: per-release
+    enforce: warning
+    tier: 2
+    reason: History lives in git + GitHub release notes; no curated CHANGELOG.md yet.
+    evidence: {absent: {file: {path: CHANGELOG.md}}}
+
+  - id: release.ci-built
+    dim: release
+    desc: Release artifacts are built by CI, never locally
+    state: manual
+    cadence: per-release
+    enforce: warning
+    tier: 2
+    evidence: {manual: {last_verified: 2026-05-21}}
+
+  # ============================ GOVERNANCE / META ========================
+  - id: governance.license
+    dim: governance
+    desc: Apache-2.0 LICENSE present, with NOTICES for vendored deps
+    state: present
+    cadence: once-must-hold
+    enforce: blocking
+    tier: 1
+    evidence: {file: {path: LICENSE, matches: 'Apache License'}}
+
+  - id: governance.readme
+    dim: governance
+    desc: README present and current
+    state: present
+    cadence: once-must-hold
+    enforce: blocking
+    tier: 1
+    evidence: {file: {path: README.md}}
+
+  - id: governance.gitignore
+    dim: governance
+    desc: .gitignore covers build artifacts, IDE/OS files, generated state
+    state: present
+    cadence: once-must-hold
+    enforce: warning
+    tier: 1
+    evidence: {file: {path: .gitignore}}
+
+  - id: governance.squash-only
+    dim: governance
+    desc: Repo is squash-merge only, with delete-branch-on-merge
+    state: enforced
+    cadence: once-must-hold
+    enforce: blocking
+    tier: 2
+    evidence: {gh_setting: {key: allow_merge_commit, equals: false}}
+
+  - id: governance.security-md
+    dim: governance
+    desc: SECURITY.md documents the vulnerability-disclosure process
+    state: planned
+    cadence: once-must-hold
+    enforce: informational
+    tier: 3
+    reason: Public repo without a published disclosure policy yet.
+    evidence: {absent: {file: {path: SECURITY.md}}}
+
+  # ================================= BUILD ===============================
+  - id: build.parallel-makeflags
+    dim: build
+    desc: Parallelism set via MAKEFLAGS in the Makefile, never passed as -j on the CLI
+    state: present
+    cadence: once-must-hold
+    enforce: warning
+    tier: 2
+    evidence: {file: {path: Makefile, matches: 'MAKEFLAGS \+= -j'}}
+
+  - id: build.time-budget
+    dim: build
+    desc: Clean dist build + test completes within CI job timeout (30 min)
+    state: enforced
+    cadence: continuous
+    enforce: blocking
+    tier: 2
+    evidence: {ci_step: {workflow: ci.yml, name: Build and test (dist)}}
+
+  # ============================ DOCUMENTATION ============================
+  - id: docs.md-links
+    dim: docs
+    desc: Internal markdown links resolve (no dead cross-references)
+    state: enforced
+    cadence: continuous
+    enforce: blocking
+    tier: 2
+    evidence: {make_target: check-md-links}
+
+  - id: docs.tla-tags
+    dim: docs
+    desc: TLA+ spec tags referenced in code/docs stay in sync with the specs
+    state: enforced
+    cadence: continuous
+    enforce: blocking
+    tier: 3
+    evidence: {make_target: check-tla-tags}
+
+  - id: docs.todo
+    dim: docs
+    desc: docs/todo.md exists as the repo TODO sink
+    state: present
+    cadence: once-must-hold
+    enforce: informational
+    tier: 1
+    evidence: {file: {path: docs/todo.md}}
+
+  # ============================== PERFORMANCE ===========================
+  - id: perf.benchmarks
+    dim: perf
+    desc: Benchmark suite exists and builds (bench/)
+    state: present
+    cadence: per-release
+    enforce: informational
+    tier: 2
+    evidence: {make_target: bench}
+
+  - id: perf.regression-tracking
+    dim: perf
+    desc: Benchmark results tracked over time to catch regressions
+    state: planned
+    cadence: continuous
+    enforce: informational
+    tier: 3
+    reason: Benchmarks run on demand; no stored baseline or CI comparison yet.
+    evidence: {absent: {ci_job: ci.yml#bench}}
+
+  # ============================== VCS / HISTORY =========================
+  - id: vcs.lfs-binaries
+    dim: vcs
+    desc: Large/binary assets (TLA traces, fixtures) tracked via Git LFS
+    state: present
+    cadence: once-must-hold
+    enforce: warning
+    tier: 2
+    evidence: {file: {path: .gitattributes}}   # TODO: confirm LFS patterns present
+
+  - id: vcs.pre-commit-hook
+    dim: vcs
+    desc: scripts/hooks/pre-commit activated (core.hooksPath) for local gating
+    state: present
+    cadence: once-must-hold
+    enforce: warning
+    tier: 2
+    evidence: {file: {path: scripts/hooks/pre-commit}}
+
+  # =================== AGENT-READINESS / ONBOARDING ====================
+  - id: agent.claude-md
+    dim: agent
+    desc: CLAUDE.md present and current (project conventions discoverable by agents)
+    state: present
+    cadence: once-must-hold
+    enforce: warning
+    tier: 1
+    evidence: {file: {path: CLAUDE.md}}
+
+  - id: agent.bullseye
+    dim: agent
+    desc: bullseye.yaml present (convergence targets discoverable)
+    state: present
+    cadence: once-must-hold
+    enforce: informational
+    tier: 2
+    evidence: {file: {path: bullseye.yaml}}
+
+  - id: agent.onboarding-docs
+    dim: agent
+    desc: Clean-clone build instructions documented; time-to-first-green-test recoverable without spelunking
+    state: present
+    cadence: once-must-hold
+    enforce: informational
+    tier: 2
+    evidence: {file: {path: docs/overview.md}}

--- a/scripts/hygiene_check.py
+++ b/scripts/hygiene_check.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["pyyaml"]
+# ///
+"""Validate hygiene.yaml against repo reality (fleet hygiene initiative).
+
+hygiene.yaml declares the repo's steady-state hygiene posture: a list of
+items, each pairing an intent with a machine-checkable `evidence` pointer.
+This validator resolves every pointer against what the repo actually
+contains — CI jobs, Makefile targets, files, gh settings, scanners — and
+fails (exit 1) when a claim has no backing reality, when a `skipped` item is
+silently running, when a required `reason` is missing, or when the declared
+maturity `tier` exceeds the tier the repo actually holds.
+
+bullseye tracks aspirational state ("achieve X"); this tracks steady-state
+("we maintain X"). Run via `make hygiene-check`.
+
+The evaluator is repo-agnostic: `check_repo(root)` returns a structured
+report for any repo root, so the fleet aggregator (hygiene_portfolio.py)
+reuses it. Destined for a shared home (or a bullseye-sibling MCP); lives in
+csp/scripts/ while the system is piloted here.
+
+Usage: hygiene_check.py [--json] [path/to/hygiene.yaml]
+       (default: ./hygiene.yaml, repo root = cwd)
+"""
+
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+VALID_STATE = {"enforced", "present", "manual", "planned", "skipped"}
+VALID_ENFORCE = {"blocking", "warning", "informational"}
+REASON_REQUIRED = {"skipped", "planned"}  # negative space must justify itself
+
+DIM_ORDER = ["correctness", "security", "quality", "deps", "release",
+             "governance", "build", "docs", "perf", "vcs", "agent"]
+
+
+@dataclass
+class Ctx:
+    """Everything an evidence resolver needs, bound to one repo."""
+    root: Path
+    workflows: dict      # filename -> parsed workflow yaml
+    owner_repo: str | None  # "owner/name" for gh api, or None
+
+
+def load_workflows(root: Path) -> dict:
+    wf = {}
+    for p in sorted((root / ".github" / "workflows").glob("*.y*ml")):
+        try:
+            wf[p.name] = yaml.safe_load(p.read_text()) or {}
+        except yaml.YAMLError as e:
+            wf[p.name] = {"__error__": str(e)}
+    return wf
+
+
+def gh_owner_repo(root: Path) -> str | None:
+    try:
+        url = subprocess.run(
+            ["git", "-C", str(root), "remote", "get-url", "origin"],
+            capture_output=True, text=True, timeout=10,
+        ).stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        return None
+    m = re.search(r"[/:]([^/:]+)/([^/:]+?)(?:\.git)?$", url)
+    return f"{m.group(1)}/{m.group(2)}" if m else None
+
+
+# --- evidence resolution ---------------------------------------------------
+# Each resolver returns (ok, detail). `ok` means "this pointer resolves
+# against reality". The `absent:` wrapper inverts a nested resolver.
+
+def resolve(ctx: Ctx, ev: dict) -> tuple[bool, str]:
+    if not isinstance(ev, dict) or len(ev) != 1:
+        return False, f"malformed evidence (need exactly one key): {ev!r}"
+    (kind, val), = ev.items()
+
+    if kind == "absent":
+        ok, detail = resolve(ctx, val)
+        return (not ok), (f"present — {detail}" if ok else f"absent — {detail}")
+
+    if kind == "ci_job":
+        wf_name, _, job_spec = str(val).partition("#")
+        job_id, _, matrix_name = job_spec.partition(":")
+        wf = ctx.workflows.get(wf_name)
+        if wf is None:
+            return False, f"workflow {wf_name} not found"
+        jobs = wf.get("jobs", {})
+        if job_id not in jobs:
+            return False, f"job '{job_id}' not in {wf_name}"
+        if matrix_name:
+            include = (jobs[job_id].get("strategy", {})
+                       .get("matrix", {}).get("include", []) or [])
+            names = [e.get("name") for e in include if isinstance(e, dict)]
+            if matrix_name not in names:
+                return False, f"matrix entry '{matrix_name}' not in job '{job_id}'"
+            return True, f"{wf_name}#{job_id} matrix '{matrix_name}'"
+        return True, f"{wf_name}#{job_id}"
+
+    if kind == "ci_step":
+        wf_name, want = val["workflow"], val["name"]
+        wf = ctx.workflows.get(wf_name) or {}
+        for job_id, job in (wf.get("jobs", {}) or {}).items():
+            for step in (job.get("steps", []) or []):
+                if isinstance(step, dict) and step.get("name") == want:
+                    return True, f"{wf_name}#{job_id} step '{want}'"
+        return False, f"no step named '{want}' in {wf_name}"
+
+    if kind == "make_target":
+        mk = (ctx.root / "Makefile").read_text()
+        if re.search(rf"(?m)^{re.escape(str(val))}\s*:", mk):
+            return True, f"Makefile target '{val}'"
+        return False, f"no Makefile target '{val}'"
+
+    if kind == "command":
+        try:
+            r = subprocess.run(str(val), shell=True, cwd=ctx.root,
+                               capture_output=True, text=True, timeout=120)
+        except (OSError, subprocess.SubprocessError) as e:
+            return False, f"command errored: {e}"
+        return (r.returncode == 0), f"`{val}` exit {r.returncode}"
+
+    if kind == "file":
+        path = ctx.root / val["path"]
+        if not path.exists():
+            return False, f"missing {val['path']}"
+        if "matches" in val:
+            try:
+                if not re.search(val["matches"], path.read_text(errors="replace")):
+                    return False, f"{val['path']} present but /{val['matches']}/ not found"
+            except OSError as e:
+                return False, f"{val['path']}: {e}"
+        return True, f"{val['path']}"
+
+    if kind == "gh_setting":
+        if ctx.owner_repo is None:
+            return False, "could not derive owner/repo from git remote"
+        try:
+            r = subprocess.run(
+                ["gh", "api", f"repos/{ctx.owner_repo}", "--jq", f".{val['key']}"],
+                capture_output=True, text=True, timeout=20,
+            )
+        except (OSError, subprocess.SubprocessError) as e:
+            return False, f"gh api failed: {e}"
+        if r.returncode != 0:
+            return False, f"gh api error: {r.stderr.strip()[:80]}"
+        got = r.stdout.strip()
+        want = json.dumps(val["equals"]) if isinstance(val["equals"], bool) else str(val["equals"])
+        return (got == want), f"{val['key']}={got} (want {want})"
+
+    if kind == "scanner":
+        tool = val["tool"]
+        cfg_ok = (ctx.root / val["config"]).exists() if "config" in val else True
+        invoked = any(tool in yaml.safe_dump(wf) for wf in ctx.workflows.values())
+        return (cfg_ok and invoked), \
+            f"{tool}: config={'ok' if cfg_ok else 'missing'} invoked={'yes' if invoked else 'no'}"
+
+    if kind == "manual":
+        lv = val.get("last_verified")
+        return (lv is not None), f"manual attestation (last_verified={lv})"
+
+    return False, f"unknown evidence kind '{kind}'"
+
+
+# --- per-item evaluation ---------------------------------------------------
+
+def evaluate(ctx: Ctx, item: dict) -> dict:
+    iid = item.get("id", "<no-id>")
+    state = item.get("state")
+    enforce = item.get("enforce")
+    errors = []
+    if state not in VALID_STATE:
+        errors.append(f"invalid state '{state}'")
+    if enforce not in VALID_ENFORCE:
+        errors.append(f"invalid enforce '{enforce}'")
+    if state in REASON_REQUIRED and not item.get("reason"):
+        errors.append(f"state '{state}' requires a reason")
+
+    ev = item.get("evidence")
+    ok, detail = resolve(ctx, ev) if ev else (False, "no evidence declared")
+
+    # `satisfied` = "this hygiene guarantee actually holds right now".
+    #   planned  -> declared gap, never satisfied (but flag if reality
+    #               outran the declaration: the thing now exists).
+    #   skipped  -> satisfied iff the thing really is absent (else: silently
+    #               running -> the skip is a lie).
+    #   else     -> satisfied iff evidence resolves.
+    advisory = None
+    if state == "planned":
+        satisfied = False
+        # planned items assert a gap (`absent:`), so ok=True == gap still
+        # open (normal). ok=False means the thing now exists -> reclassify.
+        if not ok:
+            advisory = "reality outran declaration — gap appears closed; reclassify"
+    elif state == "skipped":
+        satisfied = ok
+        if not ok:
+            advisory = "SKIP VIOLATED — declared skipped but present"
+    else:
+        satisfied = ok
+
+    return {
+        "id": iid, "dim": item.get("dim"), "tier": item.get("tier", 99),
+        "state": state, "enforce": enforce, "desc": item.get("desc", ""),
+        "satisfied": satisfied, "ok": ok, "detail": detail,
+        "errors": errors, "advisory": advisory,
+    }
+
+
+# --- tier logic ------------------------------------------------------------
+# A repo holds tier T iff every *blocking* item with tier <= T is satisfied.
+# warning/informational gaps are reported but don't lower the held tier.
+
+def derived_held_tier(results: list[dict], tiers: list[int]) -> tuple[int, list[dict]]:
+    held = 0
+    for t in sorted(tiers):
+        unmet = [r for r in results
+                 if r["tier"] <= t and r["enforce"] == "blocking" and not r["satisfied"]]
+        if unmet:
+            return held, unmet
+        held = t
+    return held, []
+
+
+def check_repo(root: Path, doc_path: Path | None = None) -> dict:
+    """Evaluate one repo's hygiene.yaml; the reusable entry point."""
+    doc_path = doc_path or (root / "hygiene.yaml")
+    doc = yaml.safe_load(doc_path.read_text())
+    ctx = Ctx(root=root, workflows=load_workflows(root), owner_repo=gh_owner_repo(root))
+
+    declared = doc.get("tier", 0)
+    aspires = doc.get("aspires", declared)
+    tier_levels = sorted(int(k) for k in (doc.get("tiers") or {1: ""}).keys())
+    results = [evaluate(ctx, it) for it in doc.get("items", [])]
+    held, blockers = derived_held_tier(results, tier_levels)
+    config_errors = [e for r in results for e in r["errors"]]
+
+    return {
+        "repo": doc.get("repo", root.name), "declared_tier": declared,
+        "aspires": aspires, "held_tier": held, "tier_ok": held >= declared,
+        "blockers": blockers, "config_errors": config_errors, "results": results,
+    }
+
+
+# --- single-repo report (CLI) ----------------------------------------------
+
+def main() -> int:
+    argv = sys.argv[1:]
+    as_json = "--json" in argv
+    positional = [a for a in argv if not a.startswith("--")]
+    if positional:
+        doc_path = Path(positional[0]).resolve()
+        root = doc_path.parent
+    else:
+        root = Path.cwd()
+        doc_path = root / "hygiene.yaml"
+
+    rep = check_repo(root, doc_path)
+    passed = rep["tier_ok"] and not rep["config_errors"]
+
+    if as_json:
+        print(json.dumps(rep, indent=2))
+        return 0 if passed else 1
+
+    GLYPH = {True: "✓", False: "✗"}
+    by_dim: dict[str, list[dict]] = {}
+    for r in rep["results"]:
+        by_dim.setdefault(r["dim"], []).append(r)
+
+    print(f"hygiene: {rep['repo']}  declared tier {rep['declared_tier']}, "
+          f"aspires {rep['aspires']}\n")
+    for dim in sorted(by_dim, key=lambda d: DIM_ORDER.index(d) if d in DIM_ORDER else 99):
+        print(f"  {dim}")
+        for r in sorted(by_dim[dim], key=lambda x: x["tier"]):
+            if r["state"] == "skipped" and r["satisfied"]:
+                g = "⊘"  # correctly absent
+            elif r["state"] == "planned":
+                g = "◦"  # declared gap
+            else:
+                g = GLYPH[r["satisfied"]]
+            print(f"    {g} [T{r['tier']} {r['enforce'][:4]}] {r['id']}: {r['detail']}")
+            if r["advisory"]:
+                print(f"        ⚠ {r['advisory']}")
+            for e in r["errors"]:
+                print(f"        ⚠ config: {e}")
+        print()
+
+    planned = [r for r in rep["results"] if r["state"] == "planned"]
+    print(f"gaps to close ({len(planned)}) on the path to tier {rep['aspires']}:")
+    for r in sorted(planned, key=lambda x: (x["tier"], x["id"])):
+        print(f"  ◦ [T{r['tier']}] {r['id']} — {r['desc']}")
+    print()
+
+    print("─" * 60)
+    print(f"held tier: {rep['held_tier']}   declared: {rep['declared_tier']}   "
+          f"{'OK' if rep['tier_ok'] else 'DRIFT'}")
+    if not rep["tier_ok"]:
+        print(f"  declared tier {rep['declared_tier']} but only tier "
+              f"{rep['held_tier']} is held; unmet blocking items below it:")
+        for r in rep["blockers"]:
+            print(f"    ✗ [T{r['tier']}] {r['id']}: {r['detail']}")
+    if rep["config_errors"]:
+        print(f"  {len(rep['config_errors'])} declaration error(s):")
+        for e in rep["config_errors"]:
+            print(f"    ✗ {e}")
+
+    print(f"\n{'PASS' if passed else 'FAIL'}")
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/hygiene_portfolio.py
+++ b/scripts/hygiene_portfolio.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["pyyaml"]
+# ///
+"""Fleet hygiene aggregator (fleet hygiene initiative).
+
+Discovers every repo under ~/work that declares a hygiene.yaml, validates
+each via hygiene_check.check_repo(), and prints a repo × dimension coverage
+matrix plus a fleet-wide gap rollup. Answers "is X covered in repo Z?" and
+"which repos lack X?" in one command — the question that motivated the
+whole initiative.
+
+Mirrors bullseye_portfolio's cross-repo aggregation. Sibling tool to
+hygiene_check.py; both are destined for a shared home (or a bullseye-sibling
+MCP) once the system leaves the csp pilot.
+
+Usage: hygiene_portfolio.py [--json] [--root DIR]   (default root: ~/work)
+"""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from hygiene_check import DIM_ORDER, check_repo  # noqa: E402
+
+ABBREV = {  # 4-char column headers for the matrix
+    "correctness": "corr", "security": "secu", "quality": "qual",
+    "deps": "deps", "release": "rels", "governance": "govn",
+    "build": "buil", "docs": "docs", "perf": "perf", "vcs": "vcs",
+    "agent": "agnt",
+}
+
+
+def discover(root: Path) -> list[Path]:
+    # Workspace layout: ~/work/<host>/<org>/<repo>/hygiene.yaml
+    found = {p.parent.resolve() for p in root.glob("*/*/*/hygiene.yaml")}
+    found |= {p.parent.resolve() for p in root.glob("hygiene.yaml")}  # root itself
+    return sorted(found, key=lambda d: d.name)
+
+
+def main() -> int:
+    argv = sys.argv[1:]
+    as_json = "--json" in argv
+    root = Path.home() / "work"
+    if "--root" in argv:
+        root = Path(argv[argv.index("--root") + 1]).expanduser().resolve()
+
+    repos = discover(root)
+    reports = []
+    for repo_root in repos:
+        try:
+            reports.append(check_repo(repo_root))
+        except Exception as e:  # one bad repo must not sink the fleet view
+            reports.append({"repo": repo_root.name, "error": str(e),
+                            "results": [], "declared_tier": 0, "held_tier": 0,
+                            "aspires": 0, "tier_ok": False, "config_errors": []})
+
+    if as_json:
+        print(json.dumps({"root": str(root), "repos": reports}, indent=2))
+        return 0
+
+    if not reports:
+        print(f"no hygiene.yaml found under {root}")
+        return 0
+
+    # --- coverage matrix: repo × dimension (satisfied/total) ---
+    name_w = max(len(r["repo"]) for r in reports)
+    name_w = max(name_w, len("repo"))
+    cell_w = 5
+    header = f"{'repo':<{name_w}}  " + "".join(
+        f"{ABBREV[d]:>{cell_w}}" for d in DIM_ORDER) + "   tier"
+    print(header)
+    print("─" * len(header))
+
+    for r in reports:
+        if "error" in r:
+            print(f"{r['repo']:<{name_w}}  ⚠ {r['error'][:60]}")
+            continue
+        by_dim: dict[str, list[dict]] = {}
+        for it in r["results"]:
+            by_dim.setdefault(it["dim"], []).append(it)
+        cells = ""
+        for d in DIM_ORDER:
+            items = by_dim.get(d, [])
+            if not items:
+                cells += f"{'·':>{cell_w}}"
+            else:
+                sat = sum(1 for it in items if it["satisfied"])
+                cells += f"{f'{sat}/{len(items)}':>{cell_w}}"
+        drift = "" if r["tier_ok"] else " DRIFT"
+        tier = f"{r['held_tier']}/{r['declared_tier']}→{r['aspires']}"
+        print(f"{r['repo']:<{name_w}}  {cells}   {tier}{drift}")
+
+    print(f"\ntier column = held/declared→aspires   "
+          f"cell = satisfied/total per dimension   · = no items\n")
+
+    # --- fleet gap rollup: which repos lack what ---
+    print("fleet gaps (planned / unsatisfied items, by repo):")
+    any_gap = False
+    for r in reports:
+        gaps = [it for it in r.get("results", [])
+                if it["state"] == "planned" or
+                (it["enforce"] == "blocking" and not it["satisfied"])]
+        if not gaps:
+            continue
+        any_gap = True
+        print(f"  {r['repo']}:")
+        for it in sorted(gaps, key=lambda x: (x["tier"], x["id"])):
+            mark = "✗" if it["enforce"] == "blocking" and not it["satisfied"] \
+                and it["state"] != "planned" else "◦"
+            print(f"    {mark} [T{it['tier']}] {it['id']}")
+    if not any_gap:
+        print("  (none — every declared item satisfied across the fleet)")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Pilot of a fleet-wide **codebase hygiene** system — tracked as 🎯T3 in `~/think` (distinct from csp's own T3.x HTTP targets). A repo's steady-state quality posture is declared once in `hygiene.yaml` and mechanically validated against reality, so drift fails loudly instead of rotting silently.

## What's here

**`hygiene.yaml`** — declarative posture across 11 dimensions (correctness, security/supply-chain, code quality, deps, release, governance, build, docs, perf, VCS, agent-readiness). Each item pairs an intent with a machine-checkable `evidence` pointer:

| evidence kind | validator checks |
|---|---|
| `ci_job` / `ci_step` | job/step exists in a workflow |
| `make_target` | Makefile target exists |
| `file {path, matches?}` | file exists (+ optional regex) |
| `gh_setting {key, equals}` | `gh api repos/:o/:r` matches |
| `scanner {tool, config?}` | configured **and** invoked in CI |
| `command` | runs, exit 0 |
| `absent: <evidence>` | nested evidence must **not** resolve |
| `manual {last_verified}` | attestation |

Three design choices distinguish it from a checklist: deliberate gaps are first-class (`state: skipped`/`planned` with a **required** `reason`, validated as genuinely absent); every item carries `cadence` + `enforce`; and `tier` is the floor the repo *guarantees* (`held`) vs `aspires` (the bullseye-style target). csp declares **tier 2 held, aspires 3**, and reports its 9 gaps — notably the near-empty security dimension — honestly.

**`scripts/hygiene_check.py`** (`make hygiene-check`) — resolves every evidence pointer. Fails when a claim has no backing reality, a `skipped` item is silently running, a required reason is missing, or the declared tier exceeds the tier actually held. `check_repo(root)` is repo-agnostic.

**`scripts/hygiene_portfolio.py`** — discovers every `hygiene.yaml` under `~/work` and prints a repo × dimension coverage matrix + fleet gap rollup, answering "is X covered in repo Z?" / "which repos lack X?" in one command.

Both scripts use `uv run` for the pyyaml dep (system python3 lacks it) and are destined for a shared home / bullseye-sibling MCP as more repos onboard.

## Verify

\`\`\`
make hygiene-check                    # PASS — tier 2 held, 9 gaps listed
uv run scripts/hygiene_portfolio.py   # csp row: secu 1/5, tier 2/2→3
\`\`\`

No existing build/test behavior changes — additive Makefile target + three new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)