### PR TITLE
Archive abandoned T3.7 HTTP/2 follow-up WIP

### DIFF
--- a/docs/papers/wip-t37-http2-followup.patch
+++ b/docs/papers/wip-t37-http2-followup.patch
@@ -1,0 +1,610 @@
+diff --git a/dist/AGENTS-CSP.md b/dist/AGENTS-CSP.md
+index 9a4a365..cfb2181 100644
+--- a/dist/AGENTS-CSP.md
++++ b/dist/AGENTS-CSP.md
+@@ -652,6 +652,10 @@ ALPN (`serve_tls`): advertises `["h2", "http/1.1"]`. If the client selects
+ `http/1.1`, the connection is handled as HTTP/1.1 over TLS using the same
+ `reader<http::request>` interface — handler code is protocol-agnostic.
+ 
++Server push: write a promise request to `endpoint::push`; it comes back on
++`endpoint::streams` for the handler to respond to. Push closes if client
++disables it via SETTINGS.
++
+ See [docs/reference/http2.md](../docs/reference/http2.md) for full reference.
+ 
+ ## Signals
+diff --git a/docs/reference/http2.md b/docs/reference/http2.md
+index d718970..2d16ded 100644
+--- a/docs/reference/http2.md
++++ b/docs/reference/http2.md
+@@ -190,8 +190,21 @@ application-level work is needed.
+ 
+ ## Server push
+ 
+-Server push is not yet implemented. The API placeholder (`http2::push`) is
+-defined in the header for future use. Tracked as a future enhancement.
++Write an `http::request` to `endpoint::push` to initiate a server push:
++
++```cpp
++http::request push_req;
++push_req.method = http::method::GET;
++push_req.url = "/style.css";
++ep.push << std::move(push_req);
++```
++
++The session sends a `PUSH_PROMISE` to the client, then delivers the push
++request back through `endpoint::streams`. The handler responds to it like
++any other request. Dropping `endpoint::push` closes the push channel.
++
++If the client has disabled server push (`SETTINGS_ENABLE_PUSH = 0`), the
++push channel is closed and writes to it are ignored.
+ 
+ ## Distribution
+ 
+diff --git a/include/csp/http2.h b/include/csp/http2.h
+index 4989e07..4010ea5 100644
+--- a/include/csp/http2.h
++++ b/include/csp/http2.h
+@@ -15,7 +15,11 @@
+ // Each HTTP/2 stream appears as a reader<http::request> + the per-request
+ // writer<http::response> embedded in http::request::respond.
+ //
+-// Server push is supported via http2::push_promise on the connection handle.
++// Server push: write an http::request to endpoint::push to initiate a server
++// push. The request must have a respond writer; the session loop sends the
++// promised request to the client and then delivers the response. If the client
++// has disabled server push the push writer is closed.
++//
+ // HPACK header compression is handled transparently by nghttp2.
+ // Flow control maps naturally to channel backpressure: the imp that reads
+ // from data providers blocks until nghttp2 grants flow-control credits.
+@@ -27,23 +31,6 @@
+ 
+ namespace csp::http2 {
+ 
+-// --- Stream endpoint ---
+-//
+-// Each HTTP/2 stream is delivered as an http::request whose respond writer
+-// accepts exactly one http::response.  This is the same interface as the
+-// HTTP/1.1 server.
+-
+-// --- Per-connection handle (for server push) ---
+-
+-struct connection_handle;
+-
+-// --- Server push ---
+-//
+-// Call push() on the connection handle to initiate a server push.
+-// Returns false if the client has disabled server push.
+-
+-bool push(connection_handle& h, http::request promised_request);
+-
+ // --- Server options ---
+ 
+ struct serve_options {
+@@ -56,10 +43,16 @@ struct serve_options {
+ // --- Per-connection endpoint ---
+ //
+ // Each accepted connection yields one endpoint.  endpoint::streams delivers
+-// one request per HTTP/2 stream.  endpoint::handle may be used for server push.
++// one request per HTTP/2 stream.
++//
++// Server push: write an http::request to endpoint::push.  The request's
++// respond writer receives the handler's response after the push is delivered.
++// Drop endpoint::push (or let it go out of scope) to stop pushing.
++// If the client disabled server push, the push writer is closed immediately.
+ 
+ struct endpoint {
+-    reader<http::request> streams;  // one per HTTP/2 stream
++    reader<http::request> streams;   // one per HTTP/2 stream
++    writer<http::request> push;      // write a request to initiate server push
+     std::string remote_addr;
+ };
+ 
+diff --git a/src/http2.cc b/src/http2.cc
+index 98f7b1c..f2bcdec 100644
+--- a/src/http2.cc
++++ b/src/http2.cc
+@@ -158,7 +158,11 @@ struct session_state {
+     io_handle* io = nullptr;  // non-owning; owned by caller
+     std::map<int32_t, stream_state> streams;
+     writer<http::request> stream_out;
++    // Server push: pending push requests sent by the application.
++    reader<http::request> push_in;
+     bool want_close = false;
++    // True if client has SETTINGS_ENABLE_PUSH = 0.
++    bool push_disabled = false;
+ };
+ 
+ // --- Data provider for response body ---
+@@ -255,6 +259,143 @@ static int on_data_chunk_recv(nghttp2_session* /*session*/,
+     return 0;
+ }
+ 
++// Forward declarations needed because these functions are mutually called.
++static void dispatch_stream(session_state* st, int32_t stream_id);
++static void drain_push_single(session_state* st, http::request push_req);
++static void drain_push_queue(session_state* st);
++
++// --- Submit a single server push ---
++//
++// Submits the PUSH_PROMISE, delivers push_req to the handler via stream_out,
++// waits for the handler's push response, and submits the push response.
++
++static void drain_push_single(session_state* st, http::request push_req) {
++    if (st->push_disabled) return;
++
++    // Build PUSH_PROMISE headers.
++    std::string method_str = http::method_name(push_req.method);
++    std::vector<nghttp2_nv> nva;
++
++    nva.push_back({
++        reinterpret_cast<uint8_t*>(const_cast<char*>(":method")),
++        reinterpret_cast<uint8_t*>(const_cast<char*>(method_str.c_str())),
++        7, method_str.size(), NGHTTP2_NV_FLAG_NO_COPY_NAME,
++    });
++    nva.push_back({
++        reinterpret_cast<uint8_t*>(const_cast<char*>(":path")),
++        reinterpret_cast<uint8_t*>(const_cast<char*>(push_req.url.c_str())),
++        5, push_req.url.size(), NGHTTP2_NV_FLAG_NO_COPY_NAME,
++    });
++    static const char kScheme[] = "https";
++    nva.push_back({
++        reinterpret_cast<uint8_t*>(const_cast<char*>(":scheme")),
++        reinterpret_cast<uint8_t*>(const_cast<char*>(kScheme)),
++        7, 5, NGHTTP2_NV_FLAG_NO_COPY_NAME,
++    });
++    for (auto& [k, v] : push_req.headers) {
++        nva.push_back({
++            reinterpret_cast<uint8_t*>(const_cast<char*>(k.c_str())),
++            reinterpret_cast<uint8_t*>(const_cast<char*>(v.c_str())),
++            k.size(), v.size(),
++            NGHTTP2_NV_FLAG_NO_COPY_NAME | NGHTTP2_NV_FLAG_NO_COPY_VALUE,
++        });
++    }
++
++    // Submit PUSH_PROMISE (associated with stream 1 as best effort).
++    int32_t push_stream_id = nghttp2_submit_push_promise(
++        st->session, NGHTTP2_FLAG_NONE,
++        1, nva.data(), nva.size(), nullptr);
++
++    if (push_stream_id < 0) {
++        st->push_disabled = true;
++        st->push_in = {};
++        return;
++    }
++
++    flush_session(st);
++
++    // Re-deliver the push request to the handler via stream_out.
++    // A fresh respond channel is created; the handler writes the push body.
++    chan<http::response> push_resp_ch;
++    push_req.respond = std::move(push_resp_ch.w);
++    push_req.version_major = 2;
++    push_req.version_minor = 0;
++    push_req.keep_alive = true;
++
++    if (!(st->stream_out << std::move(push_req))) {
++        nghttp2_submit_rst_stream(st->session, NGHTTP2_FLAG_NONE,
++                                  push_stream_id, NGHTTP2_INTERNAL_ERROR);
++        flush_session(st);
++        return;
++    }
++
++    // Wait for the push response.
++    http::response push_resp;
++    if (!(push_resp_ch.r >> push_resp)) push_resp.status = 500;
++
++    // Build and submit the push stream response.
++    std::string status_str = std::to_string(push_resp.status);
++    std::vector<nghttp2_nv> resp_nva;
++    resp_nva.push_back({
++        reinterpret_cast<uint8_t*>(const_cast<char*>(":status")),
++        reinterpret_cast<uint8_t*>(const_cast<char*>(status_str.c_str())),
++        7, status_str.size(), NGHTTP2_NV_FLAG_NO_COPY_NAME,
++    });
++    bool has_cl = false;
++    for (auto& [k, v] : push_resp.headers)
++        if (iequals(k, "content-length")) has_cl = true;
++    std::string cl_str;
++    if (!push_resp.body.empty() && !has_cl) {
++        cl_str = std::to_string(push_resp.body.size());
++        resp_nva.push_back({
++            reinterpret_cast<uint8_t*>(const_cast<char*>("content-length")),
++            reinterpret_cast<uint8_t*>(const_cast<char*>(cl_str.c_str())),
++            14, cl_str.size(), NGHTTP2_NV_FLAG_NO_COPY_NAME,
++        });
++    }
++    std::vector<std::string> lower_keys;
++    lower_keys.reserve(push_resp.headers.size());
++    for (auto& [k, v] : push_resp.headers) lower_keys.push_back(to_lower(k));
++    for (size_t i = 0; i < push_resp.headers.size(); ++i) {
++        auto& [k, v] = push_resp.headers[i];
++        resp_nva.push_back({
++            reinterpret_cast<uint8_t*>(const_cast<char*>(lower_keys[i].c_str())),
++            reinterpret_cast<uint8_t*>(const_cast<char*>(v.c_str())),
++            lower_keys[i].size(), v.size(),
++            NGHTTP2_NV_FLAG_NO_COPY_NAME | NGHTTP2_NV_FLAG_NO_COPY_VALUE,
++        });
++    }
++
++    if (push_resp.body.empty()) {
++        nghttp2_submit_response2(st->session, push_stream_id,
++                                 resp_nva.data(), resp_nva.size(), nullptr);
++        flush_session(st);
++    } else {
++        auto bd = std::make_unique<body_data>(
++            body_data{std::move(push_resp.body), 0});
++        nghttp2_data_provider2 prd;
++        prd.source.ptr = bd.get();
++        prd.read_callback = body_read_callback;
++        nghttp2_submit_response2(st->session, push_stream_id,
++                                 resp_nva.data(), resp_nva.size(), &prd);
++        flush_session(st);
++    }
++}
++
++// --- Non-blocking drain of push queue ---
++//
++// Processes all immediately available push requests from push_in.
++// Called from on_frame_recv after dispatching a stream (between requests).
++
++static void drain_push_queue(session_state* st) {
++    if (st->push_disabled || !st->push_in) return;
++
++    http::request push_req;
++    while (prialt(st->push_in >> push_req, csp::none) != csp::none) {
++        drain_push_single(st, std::move(push_req));
++    }
++}
++
+ // --- Submit response for a completed stream ---
+ //
+ // Called synchronously inside on_frame_recv. Waits for the handler to
+@@ -306,10 +447,34 @@ static void dispatch_stream(session_state* st, int32_t stream_id) {
+         return;
+     }
+ 
+-    // Wait for response.
++    // Wait for response, draining push requests that arrive while waiting.
++    // The handler may write to push_in while processing the request.
++    // Using prialt allows concurrent push delivery without deadlock.
+     http::response resp;
+-    if (!(resp_ch.r >> resp)) {
+-        resp.status = 500;
++    bool got_resp = false;
++    while (!got_resp) {
++        http::request push_req;
++        if (st->push_in) {
++            // Select between response arriving and push request arriving.
++            switch (prialt(resp_ch.r >> resp, st->push_in >> push_req)) {
++            case 0:
++                got_resp = true;
++                break;
++            case 1:
++                // A push request arrived while waiting for the response.
++                // Process it now (submits PUSH_PROMISE + waits for push resp).
++                drain_push_single(st, std::move(push_req));
++                break;
++            default:
++                // push_in closed
++                if (!(resp_ch.r >> resp)) resp.status = 500;
++                got_resp = true;
++                break;
++            }
++        } else {
++            if (!(resp_ch.r >> resp)) resp.status = 500;
++            got_resp = true;
++        }
+     }
+ 
+     // Build response headers (lowercase, :status first).
+@@ -383,6 +548,10 @@ static int on_frame_recv(nghttp2_session* /*session*/,
+         case NGHTTP2_HEADERS:
+         case NGHTTP2_DATA:
+             dispatch_stream(st, frame->hd.stream_id);
++            // After dispatching a request, drain any pending push requests.
++            // This allows the handler to initiate a push as part of
++            // responding to a request.
++            drain_push_queue(st);
+             break;
+         default:
+             break;
+@@ -393,6 +562,20 @@ static int on_frame_recv(nghttp2_session* /*session*/,
+         st->want_close = true;
+     }
+ 
++    if (frame->hd.type == NGHTTP2_SETTINGS) {
++        // Check if client disabled server push.
++        for (size_t i = 0; i < frame->settings.niv; ++i) {
++            if (frame->settings.iv[i].settings_id ==
++                    NGHTTP2_SETTINGS_ENABLE_PUSH &&
++                frame->settings.iv[i].value == 0) {
++                st->push_disabled = true;
++                // Close the push reader so the application sees push is
++                // unavailable.
++                st->push_in = {};
++            }
++        }
++    }
++
+     return 0;
+ }
+ 
+@@ -417,9 +600,11 @@ void handle_h2_connection(std::unique_ptr<io_handle> ioh,
+     internal::descr("http2/conn");
+ 
+     chan<http::request> stream_ch;
++    chan<http::request> push_ch;
+ 
+     endpoint ep;
+     ep.streams = std::move(stream_ch.r);
++    ep.push = std::move(push_ch.w);
+     ep.remote_addr = std::move(remote_addr);
+     if (!(ep_out << std::move(ep))) {
+         ioh->close();
+@@ -437,6 +622,7 @@ void handle_h2_connection(std::unique_ptr<io_handle> ioh,
+     session_state st;
+     st.io = ioh.get();
+     st.stream_out = std::move(stream_ch.w);
++    st.push_in = std::move(push_ch.r);
+ 
+     int rc = nghttp2_session_server_new(&st.session, cbs, &st);
+     nghttp2_session_callbacks_del(cbs);
+diff --git a/test/http2.test.cc b/test/http2.test.cc
+index 6982615..6571b0d 100644
+--- a/test/http2.test.cc
++++ b/test/http2.test.cc
+@@ -32,6 +32,15 @@ struct client_state {
+     std::vector<std::pair<std::string, std::string>> headers;
+     csp::bytes body;
+     bool done = false;
++
++    // Pushed responses (keyed by stream ID).
++    struct push_response {
++        std::string path;
++        std::string status;
++        std::string body;
++        bool done = false;
++    };
++    std::map<int32_t, push_response> pushes;
+ };
+ 
+ static int client_on_header(nghttp2_session* /*s*/,
+@@ -67,7 +76,48 @@ static int client_on_stream_close(nghttp2_session* /*s*/,
+                                   uint32_t /*error_code*/,
+                                   void* user_data) {
+     auto* cs = static_cast<client_state*>(user_data);
+-    if (stream_id == cs->stream_id) cs->done = true;
++    if (stream_id == cs->stream_id) {
++        cs->done = true;
++    } else {
++        auto it = cs->pushes.find(stream_id);
++        if (it != cs->pushes.end()) it->second.done = true;
++    }
++    return 0;
++}
++
++// Callback to capture push promise headers (the promised request).
++static int client_on_push_header(nghttp2_session* /*s*/,
++                                  const nghttp2_frame* frame,
++                                  const uint8_t* name, size_t namelen,
++                                  const uint8_t* value, size_t valuelen,
++                                  uint8_t /*flags*/,
++                                  void* user_data) {
++    auto* cs = static_cast<client_state*>(user_data);
++    if (frame->hd.type == NGHTTP2_PUSH_PROMISE) {
++        int32_t psid = frame->push_promise.promised_stream_id;
++        std::string k(reinterpret_cast<const char*>(name), namelen);
++        std::string v(reinterpret_cast<const char*>(value), valuelen);
++        if (k == ":path") cs->pushes[psid].path = v;
++    } else if (frame->hd.type == NGHTTP2_HEADERS) {
++        auto it = cs->pushes.find(frame->hd.stream_id);
++        if (it != cs->pushes.end()) {
++            std::string k(reinterpret_cast<const char*>(name), namelen);
++            std::string v(reinterpret_cast<const char*>(value), valuelen);
++            if (k == ":status") it->second.status = v;
++        }
++    }
++    return 0;
++}
++
++static int client_on_push_data_chunk(nghttp2_session* /*s*/,
++                                      uint8_t /*flags*/,
++                                      int32_t stream_id,
++                                      const uint8_t* data, size_t len,
++                                      void* user_data) {
++    auto* cs = static_cast<client_state*>(user_data);
++    auto it = cs->pushes.find(stream_id);
++    if (it != cs->pushes.end())
++        it->second.body.append(reinterpret_cast<const char*>(data), len);
+     return 0;
+ }
+ 
+@@ -198,6 +248,105 @@ h2_response h2_fetch(
+     return resp;
+ }
+ 
++// Push-aware version of h2_fetch.
++// Returns the regular response. Accumulated push responses are in cs.pushes.
++static h2_response h2_fetch_push(
++    uint16_t port,
++    const std::string& path,
++    client_state& cs) {
++
++    auto conn = net::dial("127.0.0.1", port);
++
++    nghttp2_session_callbacks* cbs = nullptr;
++    nghttp2_session_callbacks_new(&cbs);
++    // Use push-aware header callback for all frames (handles both HEADERS and
++    // PUSH_PROMISE frames).
++    nghttp2_session_callbacks_set_on_header_callback(cbs, [](
++            nghttp2_session* s, const nghttp2_frame* frame,
++            const uint8_t* name, size_t namelen,
++            const uint8_t* value, size_t valuelen,
++            uint8_t flags, void* ud) -> int {
++        // Dispatch to both header callbacks.
++        client_on_header(s, frame, name, namelen, value, valuelen, flags, ud);
++        client_on_push_header(s, frame, name, namelen, value, valuelen,
++                              flags, ud);
++        return 0;
++    });
++    nghttp2_session_callbacks_set_on_data_chunk_recv_callback(cbs, [](
++            nghttp2_session* s, uint8_t flags, int32_t stream_id,
++            const uint8_t* data, size_t len, void* ud) -> int {
++        client_on_data_chunk(s, flags, stream_id, data, len, ud);
++        client_on_push_data_chunk(s, flags, stream_id, data, len, ud);
++        return 0;
++    });
++    nghttp2_session_callbacks_set_on_stream_close_callback(
++        cbs, client_on_stream_close);
++
++    nghttp2_session* session = nullptr;
++    nghttp2_session_client_new(&session, cbs, &cs);
++    nghttp2_session_callbacks_del(cbs);
++
++    nghttp2_settings_entry iv[] = {{NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS, 10}};
++    nghttp2_submit_settings(session, NGHTTP2_FLAG_NONE, iv, 1);
++
++    std::string host = "127.0.0.1:" + std::to_string(port);
++    std::vector<nghttp2_nv> nva = {
++        {(uint8_t*)":method", (uint8_t*)"GET", 7, 3,
++         NGHTTP2_NV_FLAG_NO_COPY_NAME},
++        {(uint8_t*)":path", (uint8_t*)path.c_str(), 5, path.size(),
++         NGHTTP2_NV_FLAG_NO_COPY_NAME},
++        {(uint8_t*)":scheme", (uint8_t*)"http", 7, 4,
++         NGHTTP2_NV_FLAG_NO_COPY_NAME},
++        {(uint8_t*)":authority", (uint8_t*)host.c_str(), 10, host.size(),
++         NGHTTP2_NV_FLAG_NO_COPY_NAME},
++    };
++
++    int32_t sid = nghttp2_submit_request2(
++        session, nullptr, nva.data(), nva.size(), nullptr, nullptr);
++    cs.stream_id = sid;
++
++    auto flush_to_net = [&]() -> bool {
++        const uint8_t* data = nullptr;
++        for (;;) {
++            ssize_t n = nghttp2_session_mem_send(session, &data);
++            if (n == 0) break;
++            if (n < 0) return false;
++            csp::bytes chunk(data, data + n);
++            if (!(conn.output << std::move(chunk))) return false;
++        }
++        return true;
++    };
++
++    flush_to_net();
++
++    // Read until main request is done AND all pushes are done.
++    csp::bytes chunk;
++    while (!cs.done) {
++        if (!(conn.input >> chunk)) break;
++        nghttp2_session_mem_recv2(session, chunk.data(), chunk.size());
++        flush_to_net();
++    }
++    // Drain remaining frames (for push completions).
++    while (conn.input >> chunk) {
++        nghttp2_session_mem_recv2(session, chunk.data(), chunk.size());
++        flush_to_net();
++        bool all_pushes_done = true;
++        for (auto& [sid_, p] : cs.pushes)
++            if (!p.done) { all_pushes_done = false; break; }
++        if (all_pushes_done) break;
++    }
++
++    nghttp2_session_terminate_session(session, NGHTTP2_NO_ERROR);
++    flush_to_net();
++    nghttp2_session_del(session);
++
++    h2_response resp;
++    if (!cs.status.empty()) resp.status = std::stoi(cs.status);
++    resp.body.assign(cs.body.begin(), cs.body.end());
++    resp.headers = std::move(cs.headers);
++    return resp;
++}
++
+ } // anonymous namespace
+ 
+ TEST_SUITE("http2") {
+@@ -365,6 +514,80 @@ TEST_CASE("serve---404-response") {
+     csp::shutdown_runtime();
+ }
+ 
++TEST_CASE("serve---server-push") {
++    csp::shutdown_runtime();
++    csp::set_maxprocs(2);
++
++    chan<uint16_t> port_ch;
++
++    // Server: handle one request, push one resource, then respond.
++    spawn([w = std::move(port_ch.w)] {
++        auto srv = http2::serve(0);
++        w << srv.port;
++
++        http2::endpoint ep;
++        if (srv.endpoints >> ep) {
++            // Initiate a server push for /style.css before reading the request.
++            // The push handler will receive the push request on ep.streams.
++            csp::spawn([ep = std::move(ep)]() mutable {
++                // Spawn a separate imp to initiate the push so it doesn't
++                // block the request handler. The push request goes to
++                // ep.push, which the session delivers back through ep.streams
++                // after the current request is dispatched.
++                auto push_w = ep.push.copy();
++                csp::spawn([push_w = std::move(push_w)]() mutable {
++                    http::request push_req;
++                    push_req.method = http::method::GET;
++                    push_req.url = "/style.css";
++                    push_w << std::move(push_req);
++                });
++
++                // Handle requests that arrive on streams: both the original
++                // request and the push request (delivered back by the session).
++                int handled = 0;
++                while (handled < 2) {
++                    http::request req;
++                    if (!(ep.streams >> req)) break;
++                    ++handled;
++                    if (req.url == "/style.css") {
++                        std::string css = "body { color: red; }";
++                        req.respond << http::response{200,
++                            {{"content-type", "text/css"}},
++                            bytes(css.begin(), css.end())};
++                    } else {
++                        std::string html = "<html><body>Hello</body></html>";
++                        req.respond << http::response{200,
++                            {{"content-type", "text/html"}},
++                            bytes(html.begin(), html.end())};
++                    }
++                }
++            });
++        }
++    });
++
++    spawn([r = std::move(port_ch.r)] {
++        uint16_t port;
++        r >> port;
++
++        client_state cs;
++        auto resp = h2_fetch_push(port, "/index.html", cs);
++        CHECK(resp.status == 200);
++        CHECK(resp.body == "<html><body>Hello</body></html>");
++
++        // Verify the push was received.
++        CHECK(cs.pushes.size() == 1);
++        if (!cs.pushes.empty()) {
++            auto& push = cs.pushes.begin()->second;
++            CHECK(push.path == "/style.css");
++            CHECK(push.status == "200");
++            CHECK(push.body == "body { color: red; }");
++        }
++    });
++
++    schedule();
++    csp::shutdown_runtime();
++}
++
+ TEST_CASE("serve---empty-body-response") {
+     csp::shutdown_runtime();
+     csp::set_maxprocs(2);


### PR DESCRIPTION
## Summary

The `agent/T3.7-http2` worktree (`.claude/worktrees/agent-a16caf5020adec057`) had 445 lines of uncommitted work post-T3.7 retirement — server-push framing, new tests, `endpoint::push` API, docs/dist updates. T3.7 is retired; the work was never committed or merged.

Preserved as a patch under `docs/papers/` rather than discarded so it can be revisited (or applied as the seed for a future server-push target) without spelunking through git reflog.

Filed as part of the worktree/branch cleanup sweep that took the repo from 26 worktrees + ~30 stale branches down to 3 branches (master + the two in-flight PRs).

## Test plan

- [x] No code change — patch is a `.patch` file in `docs/papers/`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)