### PR TITLE
pull-based io::source streaming + pre-built library artefacts

### DIFF
--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -225,7 +225,7 @@ targets:
     achieved: 2026-06-21
   T17.3:
     name: tls::stream close_notify on consumer-drop works over buffered chan transports
-    status: identified
+    status: achieved
     value: 3.0
     cost: 2.0
     acceptance:
@@ -237,6 +237,7 @@ targets:
     - T17
     origin: T17 retirement, 2026-06-07
     discovered: 2026-06-07
+    achieved: 2026-06-28
   T17.4:
     name: tls::conn reimplemented as a thin wrapper over tls::stream
     status: identified

--- a/dist/csp.h
+++ b/dist/csp.h
@@ -7,9 +7,9 @@
 
 /* csp/csp.h */
 
-#define CSP_VERSION "0.17.0"
+#define CSP_VERSION "0.18.0"
 #define CSP_VERSION_MAJOR 0
-#define CSP_VERSION_MINOR 17
+#define CSP_VERSION_MINOR 18
 #define CSP_VERSION_PATCH 0
 
 

--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#define CSP_VERSION "0.17.0"
+#define CSP_VERSION "0.18.0"
 #define CSP_VERSION_MAJOR 0
-#define CSP_VERSION_MINOR 17
+#define CSP_VERSION_MINOR 18
 #define CSP_VERSION_PATCH 0
 
 #include <csp/internal/log.h>


### PR DESCRIPTION
Release-prep PR for **v0.18.0**. The shipped features already merged via #71–#78; this PR carries the version bump and the 🎯T17.3 retirement that ride the release.

## Release contents (v0.18.0)

The headline is the **pull-based I/O migration** (`io::source`) and the new **pre-built library distribution** (🎯T24). Bundles PRs #71–#78. Full notes go on the GitHub release; highlights:

- **Added:** pre-built per-protocol library artefacts published with each Release (🎯T24); pull-based `io::source` (🎯T17); repo hygiene posture.
- **Changed:** `http::serve` streams the request body (🎯T17.5) and reads via `io::source` (🎯T17.1/T17.2).
- **Fixed:** real TLS `close_notify` on consumer-drop, non-blocking + deadlock-free (🎯T17.3).
- **Removed:** `net::connection.input` (🎯T17.2) — a pre-1.0 breaking change; reads now go through `source`.
- **Docs:** design papers 29 (tls::conn over tls::stream), 30 (walker register provenance), 31 (buffered-chan close_notify).

## This PR's diff
- Bump `CSP_VERSION` macros 0.17.0 → 0.18.0 (`include/csp/csp.h`; regenerated `dist/csp.h`).
- Retire 🎯T17.3 (its fix shipped in #78).

## Gate
- Local `make`: **753/753 tests**, `check_md_links` + `lint_frontdoor` OK, clean tree.
- NOTICES covers all 7 vendored libs (Boost.Context, PicoTLS, nghttp2, nghttp3, ngtcp2, llhttp, wslay) — no attribution gap.

## Notes for review
- `STABILITY.md` is a stale snapshot ("as of v0.12.0") — pre-existing across 5 releases; intentionally not touched here. Worth a follow-up resurvey target.
- 🎯T24 is a release-readiness meta-target; it retires after `release.yml` actually publishes artefacts on the v0.18.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
