### PR TITLE
Fable-5 deep audit: csp (1 high) — finding + target

### DIFF
--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -1054,6 +1054,17 @@ targets:
     origin: subdivide(🎯T30)
     discovered: 2026-06-30
     achieved: 2026-07-01
+  T33:
+    name: csp sizes stack slots from a true high-water bound so a Small slot can never be chosen for an imp that overflows it
+    status: identified
+    value: 8.0
+    cost: 5.0
+    acceptance:
+    - The stack-slot size class is chosen from a sound upper bound (is_exact analyser), not a checkpoint-sampled high-water estimate that can under-count — restoring the T3.4.4 invariant that only the inexact fallback magnitude improves
+    - An imp whose true peak stack can exceed the Small slot is never placed in one; a test exercises the shallow-sample-then-deep-descent boundary under -DCSP_ANALYSE_STACKS on arm64
+    context: 'HIGH, confirmed by two-lens verification (2026-07-03). src/csp.cc:476: StackClass::Small is selected purely from profile_needed = high_water*1.5 + headroom, with no is_exact gate and no analyser call — an independent path that preempts the sound analyser. The high-water is a do_switch checkpoint sample, not a peak, so a helper that grows and unwinds between two channel ops is never sampled; a shallow instance''s sample then gates a deep instance''s Small allocation. Arena slots have only a 4 KB software guard (no PROT_NONE page on arm64), so a descent into the neighbouring slot silently corrupts an adjacent imp''s Imp control block and stack. The verifier confirmed this violates the repo''s own T3.4.4 acceptance criteria. Found by Fable-5 audit 2026-07 (docs/audit/fable-2026-07.md).'
+    origin: manual
+    discovered: 2026-07-03
   T4:
     name: API safety gaps are closed
     status: achieved

--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -957,6 +957,17 @@ targets:
     origin: manual
     discovered: 2026-03-28
     achieved: 2026-04-28
+  T32:
+    name: csp sizes stack slots from a true high-water bound so a Small slot can never be chosen for an imp that overflows it
+    status: identified
+    value: 8.0
+    cost: 5.0
+    acceptance:
+    - The stack-slot size class is chosen from a sound upper bound, not a checkpoint-sampled high-water estimate that can under-count
+    - An imp whose usage can exceed the Small slot is never placed in one; add a test exercising the boundary
+    context: 'HIGH. src/csp.cc:476: the checkpoint-sampled high-water table under-sizes Small stack slots, causing silent cross-imp stack corruption. Unverified Fable-5 finder-stage candidate (verification interrupted by an API spend limit); verify before implementing. See docs/audit/fable-2026-07.md.'
+    origin: manual
+    discovered: 2026-07-02
   T4:
     name: API safety gaps are closed
     status: achieved

--- a/docs/audit/fable-2026-07.md
+++ b/docs/audit/fable-2026-07.md
@@ -1,0 +1,104 @@
+# Fable-5 Deep Audit — csp
+
+**Date:** 2026-07-02  
+**Auditor:** Claude Fable 5 — multi-agent workflow (recon → per-dimension finders → two-lens adversarial verification → synthesis)  
+**Verification status:** 0 of 2 candidate findings passed two-lens adversarial verification before an API spend limit interrupted the run. The remainder are **finder-stage candidates** — high-signal (the finders reproduced many via scratch compiles) but not yet adversarially verified. **Verify before implementing.**  
+
+> Defensive maintenance review of the maintainer's own code. Each finding is a latent defect to repair, ranked by severity.
+
+## Architecture (as mapped during the audit)
+
+CSP is a header-plus-source C++20 CSP library. The public surface (include/csp/csp.h, ~1600 lines) exposes typed writer<T>/reader<T> endpoints, chan_op<T> RAII operations, and variadic alt/prialt. Templates never touch scheduler internals: they build type-erased internal::ChanOp descriptors (a Waiter = Channel*|flags, a void* message, a Slot*, and an eptr_dst) and call three C-ABI functions implemented in src/channel.cc: prialt_begin (find a peer with channel mutexes held, return raw src/dst pointers), an inline typed transfer at the call site, then alt_end (unlock, schedule the peer). This is the two-phase protocol (docs/papers/03). Endpoints are refcounted Slots that point at a heap Channel; a chan<T>(N) buffered channel is actually a spawned filter imp running a 2-arm alt loop over a ring buffer (csp.h ~1578), so buffering is itself concurrency.
+
+The execution substrate is an M:N work-stealing scheduler. Runtime (src/runtime.cpp, include/csp/internal/runtime.h) owns a fixed-capacity vector of Processors (P0 = main thread runs main_loop; P1..N run worker_loop on OS threads), a global_run_queue under global_mu, and per-Processor circular doubly-linked local run queues under each run_mu. Imps are fcontext coroutines (Boost.Context jump_fcontext) whose stacks come from StackPool (arena of 128KB slots on Linux, VirtualAlloc demand-commit on Windows, heap under sanitizers). The current imp is tracked in a thread_local Imp* g_imp deliberately isolated in src/csp_globals.cpp as its own TU — the TLS-address-caching-across-jump_fcontext bug (docs/tls-caching-bug.md) forces the wrapper-call access pattern via current_imp()/set_current_imp(). A watchdog thread adds surplus Ps when a worker stalls; surplus Ps wind down after 5s idle. Workers park on a per-worker Note (futex-backed binary semaphore, include/csp/internal/note.h); main_loop/run/quiescent_loop/await_idle park on the shared park_cv. unpark_one (runtime.cpp:158) wakes exactly one sleeping worker (or flags one awake worker's Note) plus notify_all on park_cv.
+
+The heart of the concurrency correctness is the suspend/wake handshake (src/csp.cc). switch_to wraps jump_fcontext with acquire/release fences on Imp::ctx_ plus ASan/TSan fiber annotations. do_switch(detach) suspends the running imp; the suspending_ flag marks the unlock_all→do_switch window so a concurrent schedule() from a waker on another OS thread sets wake_pending_ instead of double-queueing; drain_suspended (csp.cc:95) runs on the resuming context under global_mu to clear suspending_ and re-push if wake_pending_. Endpoint death, timers, blocking-pool completions, and reactor events all funnel to Imp::make_runnable()→schedule(). A quiescence_scope with an enter/leave counter (used by fake_clock) tracks active imps to drive deterministic virtual-time advance; make_runnable/do_switch juggle qs_sleeping_ to enter-at-schedule (docs/papers/18).
+
+External I/O sits on a single Reactor thread (src/reactor.cc) using kqueue (macOS) / epoll+timerfd+eventfd (Linux) / thread-pool callbacks (Windows). Reactor events fire by erasing a writer<> from a map, whose destructor drops the write endpoint, delivering a death signal observable via prialt(~reader). Timer idents are tagged with bit 63 (kTimerIdentBit) to keep them disjoint from fd numbers in fire_signal (docs/papers/27). A BlockingPool (src/blocking_pool.cc) runs blocking syscalls (e.g. getaddrinfo) on worker threads and calls make_runnable on completion. Unix signals use a self-pipe (src/signal.cc). Cancellation (src/cancel.cc) is a shared_ptr<cancel_state> stored in a HAMT dynamic-scope variable; dropping its writer fires vultures on the done() signal channel. Both the reactor thread and blocking-pool threads call make_runnable/schedule without a bound Processor — a cross-thread scheduler entry point.
+
+## Load-bearing invariants
+
+- g_imp TLS must be re-resolved (not cached) across every jump_fcontext — csp_globals.cpp keeps it in a separate TU and uses noinline accessors; violation writes the wrong OS thread's TLS slot and corrupts the scheduler (docs/tls-caching-bug.md).
+- Every sleep→runnable transition calls quiescence_scope::enter() exactly once and every runnable→sleep/exit calls leave() exactly once (guarded by qs_sleeping_ exchange); imbalance either advances fake time mid-transfer (data corruption) or livelocks the hook (docs/papers/18).
+- The suspending_ / wake_pending_ protocol must be atomic w.r.t. schedule(): an imp in the unlock_all→do_switch window must never be pushed to a run queue by a waker (would run on two OS threads at once). drain_suspended and schedule() coordinate under global_mu (csp.cc:95-116, 183-209).
+- A Channel is freed exactly once, only when alive_ (endpoints=2 plus prialt re-resolution pins plus sleeping-waiter references) reaches 0; the last decrementer deletes and then mem_releases both Slots (channel.cc:173-181, 223-231). Any missed pin or double-decrement is a UAF/double-free.
+- prialt_begin must pin (alive_.fetch_add) each resolved Channel under the Slot spinlock before releasing it, so a concurrent endpoint death cannot free the channel between resolve and lock_all (channel.cc:270-311; docs/papers/11-channel-reresolution-uaf.md).
+- Channel mutexes are always acquired in ascending id_ order (sorted set in prialt_begin, id-ordered pair in swap_slots) — the sole deadlock-avoidance discipline across multi-channel alt and slot swap (channel.cc:314-330, 685-691).
+- alt_state CAS ALT_WAITING→ALT_CLAIMED is the single arbiter of who wakes a waiter; exactly one waker may claim a given suspended imp, and signal_ is only written by the successful claimant (channel.cc:120-166, 386-411).
+- A registered ChanOp in a channel waiter/vulture ring points into the suspended imp's live stack; that stack must not be freed or shrunk below the descriptor while the imp is suspended (maybe_shrink runs before suspend and only reclaims below SP; ASan/TSan fiber annotations preserve fake-stacks).
+- StackPool arena slots have only a 4KB software guard zone checked at CSP suspend checkpoints (check_stack_overflow); the analyser-selected Small (16KB) slot must never be chosen for an imp that can exceed it, or the soft guard traps (csp.cc spawn slot-class logic, stack_pool.h).
+- Reactor ident namespaces are provably disjoint: timer idents carry bit 63, fd numbers are < 2^31; fire_signal routes solely on that bit (reactor.cc:256, 382-398).
+- live_gs/daemon_gs accounting must exactly track live vs daemon imps; run()/main_loop completion and the park_cv wakeups on the last imp's death depend on it (csp.cc destroy_imp:234-251).
+- Runtime::shutdown's stability loop must observe two equal successive num_procs_ reads so every watchdog-added surplus worker is woken and joined (docs/papers/26; runtime.cpp:110-153).
+
+## Trust boundaries
+
+- Network sockets: TCP/TLS/HTTP/HTTP2/HTTP3/QUIC/WebSocket data enters via src/net.cc, io.cc, tls.cc, http*.cc, ws.cc, quic.cc through the non-blocking reactor; untrusted wire bytes drive vendored parsers (llhttp, nghttp2/3, ngtcp2, picotls, wslay).
+- DNS resolution: host/service strings passed to getaddrinfo on the blocking pool (io.cc resolve, blocking_pool.cc) — result addrinfo lifetime and error codes cross the pool→imp boundary.
+- fd numbers from accept()/dial() flow into the reactor as event idents; fd reuse after close races with pending event delivery (reactor.cc fire_signal / cancel_fd, io.cc).
+- Unix signals: async-signal-safe handler writes signal numbers into self-pipes shared with imps (src/signal.cc); handler reads g_sig_pipe_count/sig_mask/write_fd concurrently with registration and teardown.
+- Environment/config: CSP_MAXPROCS (csp_globals.cpp resolve_maxprocs) and CSP_ANALYSE_STACKS gate proc count and stack-slot sizing.
+- Application callables: user filter/part functions, cancellation handlers, and supervision restart policies run inside imps and may throw; exceptions are caught silently at the imp boundary (csp.cc start:443-447) or delivered in-band across channels.
+- OS API return values: kevent/epoll_ctl/timerfd_settime/pipe/mmap results are largely assert()-checked (compiled out in release), so a failing syscall becomes undefined behaviour rather than a handled error (reactor.cc, stack_pool.cc, signal.cc).
+
+## Findings
+
+Ordered by severity. Locations are as reported by the finder and should be confirmed against current line numbers.
+
+### F1 — [HIGH] Checkpoint-sampled high-water table under-sizes Small stack slots, causing silent cross-imp stack corruption
+
+- **Location:** `src/csp.cc:476`
+- **Dimension:** -
+- **Invariant violated:** A Small (16 KB) arena slot must never be chosen for an imp whose true peak stack depth can exceed it; the value gating that choice must be an upper bound on the imp's real stack usage. Arena overflow is only detectable at CSP suspend checkpoints (there is no hardware guard page), so choosing a slot the imp can outgrow between checkpoints silently corrupts an adjacent imp's stack.
+- **Failure scenario:** Build with -DCSP_ANALYSE_STACKS on arm64 (arena mode — e.g. macOS M4 / Linux arm64). A lambda type F is spawned more than once (parts, buffered channels, and per-connection server imps all do this). Instance A takes a shallow path: it does a channel op, then light work, then another op; at each op do_switch records depth ~2 KB, so g_high_water[spawn_entry<F>] = ~2 KB. Instance B is the same type F but its data drives a deep phase: after its first channel op it calls a helper that consumes ~40 KB of stack (deep recursion or a large local buffer) and returns before its next op. spawn(B) computes profile_needed = 2048 + 1024 + 2048 + sizeof(Imp) ~= 5.4 KB <= 16 KB and picks StackClass::Small (16 KB usable, 20 KB slot, 4 KB software guard, mapped RW with no mprotect). B runs: after the first op checkpoint passes, the 40 KB helper drives SP from the slot top down ~40 KB — past overflow_limit (base+4 KB) and ~20 KB below the slot base into the neighbouring slot in the same slab, overwriting that imp's Imp object (ctx_, prev_/next_ run-queue links, alt_state, refcounts) and stack. No mprotect means no SIGSEGV; the helper returns and SP climbs back above overflow_limit, so at B's next op check_stack_overflow sees SP > overflow_limit and never traps. Concrete outcome: the scheduler later dereferences the corrupted next_ (segfault), resumes the neighbour from a corrupted fcontext (arbitrary control-flow), or silently delivers corrupted channel data.
+- **Evidence:**
+
+```
+// csp.cc:343-349 (recorded ONLY at the do_switch checkpoint, misses between-op peaks; keyed per EntryFn = spawn_entry<F>, shared across all instances):
+    if (self->entry_fn_ && self->entry_sp_) {
+        auto* top = static_cast<char*>(self->entry_sp_);
+        auto* cur = static_cast<char*>(fp);
+        if (top > cur) {
+            record_stack_high_water(self->entry_fn_, static_cast<size_t>(top - cur));
+        }
+    }
+// csp.cc:476-481 (Small selected purely from that under-measured, cross-instance value):
+    if (size_t hw = ::csp::detail::get_stack_high_water(start_f); hw > 0) {
+        size_t profile_needed = hw + hw / 2 + kHeadroomFloor + sizeof(Imp);
+        if (profile_needed <= kSmallUsable) {
+            slot_cls = StackClass::Small;
+        }
+    }
+// stack_pool.cc:126 (Small slab mapped RW, no PROT_NONE guard page -> overflow is silent):
+    void* base = mmap(nullptr, kArenaSmallSlabSize, PROT_READ | PROT_WRITE, flags, -1, 0);
+```
+
+- **Fix sketch:** Do not derive slot down-sizing from checkpoint-sampled depth — it provably cannot observe between-checkpoint peaks and aggregates across closure instances with different data-dependent depths. Either (a) install a real PROT_NONE guard page at the bottom of each arena slot (as the per-stack mmap path already does at stack_pool.cc:385) so a mis-sized slot faults deterministically at the moment of overflow instead of corrupting a neighbour, and/or (b) gate StackClass::Small strictly on a sound static upper bound (analyser is_exact) rather than empirical high-water samples, and drop the csp.cc:476-481 profile->Small path (keep the profile only for the never-shrinking Default slot / analyser budget refinement).
+- **Verification:** Before: build test binary with -DCSP_ANALYSE_STACKS; temporarily mprotect(base+kArenaSmallSlotGuard region top boundary, PAGE, PROT_NONE) on each Small slot OR write a known sentinel into each slot's Imp; run the two-instance repro above and observe the sentinel/neighbour Imp being overwritten (or the injected guard faulting inside B's 40 KB helper). Also log the value passed to record_stack_high_water for F versus an instrumented deepest-SP sample to show hw << true peak. After fix: same repro either traps cleanly via the hardware guard at the overflow instant, or F is never assigned a Small slot; no neighbour corruption and the scheduler run-queue stays intact.
+
+### F2 — [MEDIUM] cancel_reason() can return nullptr (or race the exception_ptr) for a cancelled scope because reason is published after the cancelled flag with no release/acquire pairing
+
+- **Location:** `src/cancel.cc:26`
+- **Dimension:** -
+- **Invariant violated:** If a cancellation scope is observed as cancelled (cancelled == true), the reason exception_ptr set for that cancellation must be visible and safely readable by any observer; reading reason must never race with the store that sets it.
+- **Failure scenario:** Runtime with maxprocs >= 2. Imp A on OS-thread T1 performs a manual cooperative check `if (auto r = csp::cancel_reason()) { std::rethrow_exception(r); }` in a compute loop (a plausible pattern — cancel_reason() is a documented public API with no threading caveat and is used exactly this way in io.cc/timer.cc). Imp B on OS-thread T2 calls `guard(std::make_exception_ptr(my_error{}))`. cancel() does `cancelled.exchange(true)` (seq_cst) FIRST, then `reason = ep` (plain, non-atomic) SECOND. In cancel_reason(), A does `if (!state->cancelled) return {};` (observes true) then reads `state->reason`. Because the seq_cst store to `cancelled` is sequenced BEFORE the plain write to `reason`, A's acquire of `cancelled==true` establishes no happens-before to the `reason` write. Two concrete bad outcomes: (1) A observes cancelled==true but reads `reason` while it is still the default null (B has not yet executed reason=ep) -> cancel_reason() returns nullptr for a genuinely-cancelled scope -> A's `if` is false and A silently misses the cancellation; (2) A's copy-return of `state->reason` reads the exception_ptr concurrently with B's assignment -> data race on a non-atomic std::exception_ptr -> torn pointer or concurrent refcount inc/dec on the shared exception object -> UAF/double-free/crash. The done()-woken paths (io.cc:29, timer.cc:39/57) are unaffected because their wake goes through the channel-mutex + run-queue lock chain, which independently publishes reason.
+- **Evidence:**
+
+```
+void cancel(std::exception_ptr ep) {
+    if (!cancelled.exchange(true)) {
+        reason = ep;                 // plain write, sequenced AFTER the seq_cst exchange
+        trigger = {};
+    }
+}
+...
+std::exception_ptr cancel_reason() {
+    auto state = *g_cancel;
+    if (!state || !state->cancelled) return {};  // observes cancelled==true
+    return state->reason;                          // plain read: no HB to the write above
+}
+```
+
+- **Fix sketch:** Establish an explicit release/acquire edge for reason. Add `std::atomic<bool> reason_ready{false};` to cancel_state; in cancel() write `reason = ep; reason_ready.store(true, std::memory_order_release);` before dropping trigger; in cancel_reason() gate on `if (!state || !state->reason_ready.load(std::memory_order_acquire)) return {}; return state->reason;`. (Keeping the cancelled exchange for idempotency/trigger-drop is fine.) Alternatively store the reason in a std::atomic<std::shared_ptr<...>> or protect it with a small mutex. This also hardens the io.cc/timer.cc paths at no cost.
+- **Verification:** Before: build with -fsanitize=thread and add a test under set_maxprocs(4) that spawns two imps in the same cancel scope — one spinning on `while (running) { if (cancel_reason()) break; csp::yield(); }`, the other calling `guard(std::make_exception_ptr(std::runtime_error("x")))` — repeated over many iterations/scopes; TSan reports a data race on cancel_state::reason (write in cancel.cc:26 vs read in cancel.cc:154), and asserting the poller always retrieves a non-null reason once cancelled occasionally fails. After the fix, TSan is clean and the non-null assertion holds.
+

--- a/docs/audit/fable-2026-07.md
+++ b/docs/audit/fable-2026-07.md
@@ -1,8 +1,8 @@
 # Fable-5 Deep Audit — csp
 
-**Date:** 2026-07-02  
+**Date:** 2026-07-02 (findings) · 2026-07-03 (re-verification)  
 **Auditor:** Claude Fable 5 — multi-agent workflow (recon → per-dimension finders → two-lens adversarial verification → synthesis)  
-**Verification status:** 0 of 2 candidate findings passed two-lens adversarial verification before an API spend limit interrupted the run. The remainder are **finder-stage candidates** — high-signal (the finders reproduced many via scratch compiles) but not yet adversarially verified. **Verify before implementing.**  
+**Verification:** the 1 critical/high findings were each re-checked by two independent adversarial verifiers (a reachability lens and an invariant-validity lens, each defaulting to "refuted"). Result: **1 confirmed, 0 uncertain, 0 refuted** (refuted findings are set aside, not filed as targets). Medium/low candidates below remain finder-stage.  
 
 > Defensive maintenance review of the maintainer's own code. Each finding is a latent defect to repair, ranked by severity.
 
@@ -43,10 +43,11 @@ External I/O sits on a single Reactor thread (src/reactor.cc) using kqueue (macO
 
 ## Findings
 
-Ordered by severity. Locations are as reported by the finder and should be confirmed against current line numbers.
+Ordered by severity. Locations are as reported by the finder; confirm against current line numbers.
 
-### F1 — [HIGH] Checkpoint-sampled high-water table under-sizes Small stack slots, causing silent cross-imp stack corruption
+### F1 — [HIGH] · re-verified: **CONFIRMED** Checkpoint-sampled high-water table under-sizes Small stack slots, causing silent cross-imp stack corruption
 
+- **Re-verification:** **CONFIRMED** (confidence high; adjusted severity high). [confirmed] The invariant is real and explicitly stated in the repo's own design: paper 08 §7 (analyser must never underestimate), the audit's own invariant line (fable-2026-07.md:29), and — most decisively — the T3.4.4 acceptance criteria in bullseye.yaml:802-803, which mandate that the profiled high-water only refine indirect_call_budget while "is_exact remains false; only the magnitude of the inexact fallback improves." Small selection was designed to stay gated on is_exact (a sound static upper bound), per T3.4.1.  The code at src/csp.cc:476-481 violates this: it selects StackClass::Small purely from profile_needed = hw + hw/2 + kHeadroomFloor + sizeof(Imp) with no is_exact gate and no analyser call, an independent path that runs before (and can preempt) the analyser path. This is conf…
 - **Location:** `src/csp.cc:476`
 - **Dimension:** -
 - **Invariant violated:** A Small (16 KB) arena slot must never be chosen for an imp whose true peak stack depth can exceed it; the value gating that choice must be an upper bound on the imp's real stack usage. Arena overflow is only detectable at CSP suspend checkpoints (there is no hardware guard page), so choosing a slot the imp can outgrow between checkpoints silently corrupts an adjacent imp's stack.
@@ -74,7 +75,7 @@ Ordered by severity. Locations are as reported by the finder and should be confi
 ```
 
 - **Fix sketch:** Do not derive slot down-sizing from checkpoint-sampled depth — it provably cannot observe between-checkpoint peaks and aggregates across closure instances with different data-dependent depths. Either (a) install a real PROT_NONE guard page at the bottom of each arena slot (as the per-stack mmap path already does at stack_pool.cc:385) so a mis-sized slot faults deterministically at the moment of overflow instead of corrupting a neighbour, and/or (b) gate StackClass::Small strictly on a sound static upper bound (analyser is_exact) rather than empirical high-water samples, and drop the csp.cc:476-481 profile->Small path (keep the profile only for the never-shrinking Default slot / analyser budget refinement).
-- **Verification:** Before: build test binary with -DCSP_ANALYSE_STACKS; temporarily mprotect(base+kArenaSmallSlotGuard region top boundary, PAGE, PROT_NONE) on each Small slot OR write a known sentinel into each slot's Imp; run the two-instance repro above and observe the sentinel/neighbour Imp being overwritten (or the injected guard faulting inside B's 40 KB helper). Also log the value passed to record_stack_high_water for F versus an instrumented deepest-SP sample to show hw << true peak. After fix: same repro either traps cleanly via the hardware guard at the overflow instant, or F is never assigned a Small slot; no neighbour corruption and the scheduler run-queue stays intact.
+- **Verification step:** Before: build test binary with -DCSP_ANALYSE_STACKS; temporarily mprotect(base+kArenaSmallSlotGuard region top boundary, PAGE, PROT_NONE) on each Small slot OR write a known sentinel into each slot's Imp; run the two-instance repro above and observe the sentinel/neighbour Imp being overwritten (or the injected guard faulting inside B's 40 KB helper). Also log the value passed to record_stack_high_water for F versus an instrumented deepest-SP sample to show hw << true peak. After fix: same repro either traps cleanly via the hardware guard at the overflow instant, or F is never assigned a Small slot; no neighbour corruption and the scheduler run-queue stays intact.
 
 ### F2 — [MEDIUM] cancel_reason() can return nullptr (or race the exception_ptr) for a cancelled scope because reason is published after the cancelled flag with no release/acquire pairing
 
@@ -100,5 +101,5 @@ std::exception_ptr cancel_reason() {
 ```
 
 - **Fix sketch:** Establish an explicit release/acquire edge for reason. Add `std::atomic<bool> reason_ready{false};` to cancel_state; in cancel() write `reason = ep; reason_ready.store(true, std::memory_order_release);` before dropping trigger; in cancel_reason() gate on `if (!state || !state->reason_ready.load(std::memory_order_acquire)) return {}; return state->reason;`. (Keeping the cancelled exchange for idempotency/trigger-drop is fine.) Alternatively store the reason in a std::atomic<std::shared_ptr<...>> or protect it with a small mutex. This also hardens the io.cc/timer.cc paths at no cost.
-- **Verification:** Before: build with -fsanitize=thread and add a test under set_maxprocs(4) that spawns two imps in the same cancel scope — one spinning on `while (running) { if (cancel_reason()) break; csp::yield(); }`, the other calling `guard(std::make_exception_ptr(std::runtime_error("x")))` — repeated over many iterations/scopes; TSan reports a data race on cancel_state::reason (write in cancel.cc:26 vs read in cancel.cc:154), and asserting the poller always retrieves a non-null reason once cancelled occasionally fails. After the fix, TSan is clean and the non-null assertion holds.
+- **Verification step:** Before: build with -fsanitize=thread and add a test under set_maxprocs(4) that spawns two imps in the same cancel scope — one spinning on `while (running) { if (cancel_reason()) break; csp::yield(); }`, the other calling `guard(std::make_exception_ptr(std::runtime_error("x")))` — repeated over many iterations/scopes; TSan reports a data race on cancel_state::reason (write in cancel.cc:26 vs read in cancel.cc:154), and asserting the poller always retrieves a non-null reason once cancelled occasionally fails. After the fix, TSan is clean and the non-null assertion holds.
 


### PR DESCRIPTION
## Fable-5 deep audit — csp

Authorized defensive reliability review of the maintainer's own code. Adds the audit report and files the critical/high findings as bullseye targets to review and implement.

**Verification status:** 0 of 2 findings passed two-lens adversarial verification before an API spend limit interrupted the run; the remainder are finder-stage candidates (high-signal — several reproduced via scratch compiles) and must be verified before implementing.

**Targets filed:** T32 (critical/high). Medium/low candidates are documented in the report but not yet filed as targets.

Full detail (evidence, fix sketch, repro steps) and the recon/architecture map are in `docs/audit/fable-2026-07.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
