### PR TITLE
Small stack-slot sizing gated on a sound analyser bound (T33 audit remediation)

### DIFF
--- a/dist/csp.h
+++ b/dist/csp.h
@@ -7,9 +7,9 @@
 
 /* csp/csp.h */
 
-#define CSP_VERSION "0.20.0"
+#define CSP_VERSION "0.21.0"
 #define CSP_VERSION_MAJOR 0
-#define CSP_VERSION_MINOR 20
+#define CSP_VERSION_MINOR 21
 #define CSP_VERSION_PATCH 0
 
 

--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#define CSP_VERSION "0.20.0"
+#define CSP_VERSION "0.21.0"
 #define CSP_VERSION_MAJOR 0
-#define CSP_VERSION_MINOR 20
+#define CSP_VERSION_MINOR 21
 #define CSP_VERSION_PATCH 0
 
 #include <csp/internal/log.h>


### PR DESCRIPTION
Release-prep PR for **v0.21.0** — bumps the `CSP_VERSION` macros 0.20.0 → 0.21.0 (`include/csp/csp.h`, regenerated `dist/csp.h`). The shipped work already merged via #86–#88.

## Release contents (v0.21.0)

Audit-remediation release (Fable-5 deep audit). Hardens the **opt-in** stack-depth analyser (`-DCSP_ANALYSE_STACKS`, off by default); the default source/dist library is unchanged.

- **Fixed — 🎯T33:** `spawn()` gates `StackClass::Small` on the analyser's sound `is_exact` bound instead of an unsound checkpoint-sampled high-water (which could place a deep imp in a Small slot and silently corrupt a neighbouring arena imp). Differential regression test + previously-missing `CSP_ANALYSE_STACKS` CI coverage. (#88)
- **Documented — 🎯T31:** latent walker ASan over-read filed as a tracked target (fix pending). (#86) + audit report under `docs/audit/`. (#87)

## Gate
- Local `make`: **757/757 tests**, clean tree.
- 🎯T33 already retired in #88's diff (its lifecycle rode that PR); 🎯T31 stays open.
- `homebrew_tap: disabled` — releases ship source + prebuilt libs, no tap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
