### PR TITLE
🎯T31: fix ASan over-read in stack-analysis audit fixture

### DIFF
--- a/bullseye.yaml
+++ b/bullseye.yaml
@@ -570,6 +570,13 @@ targets:
       Strong evidence this is a real latent concurrency bug, not infra flakiness: across the last ~10 master runs the arm64 TSan job completes in 2–3 min, so 30 min is a ~15× hang, not slow-creep; the triggering diff was pure data (cannot affect the build/test); and it is arm64-TSan-specific (x86_64 TSan passed at 3 min in the same run), pointing at an arm64 weak-memory-ordering window that TSan timing widens.
 
       Theories, most→least likely: (1) intermittent deadlock/livelock in the scheduler/channel runtime, arm64-specific ordering window; (2) main-loop busy-spin that fails to make progress under some interleavings (csp has prior form — paper 22 'main-loop busy-spin diagnosis', 🎯T26/T27; web_crawler deadlock 🎯T26); (3) a test-side real-time wait starved under TSan load. The watchdog acceptance criterion exists because the current CI captures nothing on a timeout, making this hard to root-cause after the fact — fix observability first so the next occurrence is actionable.
+
+      --- Watchdog design (scoped 2026-07-05 while shipping 🎯T31; ready to implement as this target's own PR) ---
+      Mechanism: make a hang manifest as a diagnosable step *failure* (with a core) instead of a job-level `cancelled`, then let a `failure()`-gated GDB step backtrace it.
+      1. Makefile: add an opt-in `TEST_TIMEOUT` (seconds). When set, the `test` recipe runs the binary as `timeout -s ABRT --kill-after=60 $(TEST_TIMEOUT) ./$(TARGET)` (GNU `timeout` on Linux; `gtimeout` on macOS). Keeping the wrapper in the recipe means it uses `$(TARGET)` and the correct BUILDDIR automatically. With `ulimit -c unlimited` + `kernel.core_pattern=core.%p` (already set for Linux CI), SIGABRT on expiry cores the *test* process (it is timeout's direct child) and exits 134 → recipe fails → step fails.
+      2. ci.yml: on the `Linux arm64 TSan` sanitize row only, pass `TEST_TIMEOUT=1200` (20 min < the 30-min job cap) to the `make test-dist` step.
+      3. GOTCHA found 2026-07-05: the sanitize job's existing `GDB backtrace on crash` step hardcodes `./build/dist/csp_tests`, which is STALE — the dist-TSan binary is actually `build/thread-dist-notls/csp_tests` (BUILDDIR = build/$(SANITIZE)-$(CSP_INCLUDE)[-notls]; test-dist runs the recursive `make CSP_INCLUDE=dist CSP_TLS=0 test`). The ASan rows are `build/address-undefined-dist[-notls]/csp_tests`. That step has never fired (the hang is a cancel, not a core), so the wrong path went unnoticed. The backtrace step must discover the binary via `find build -name csp_tests -type f` (try each against `core.*`) rather than hardcode, which also fixes the pre-existing bug.
+      Validate locally what is validatable: `gtimeout -s ABRT` on a deliberately-hung test → confirm core + non-zero exit + lldb/gdb `thread apply all bt`. The hang path itself is not locally reproducible, so this only fixes observability; root-cause + the 20-run window remain.
     tags:
     - ci
     - concurrency
@@ -1054,24 +1061,12 @@ targets:
     origin: subdivide(🎯T30)
     discovered: 2026-06-30
     achieved: 2026-07-01
-  T33:
-    name: csp sizes stack slots from a true high-water bound so a Small slot can never be chosen for an imp that overflows it
-    status: achieved
-    value: 8.0
-    cost: 5.0
-    actual_cost: 3.0
-    achieved: 2026-07-04
-    acceptance:
-    - The stack-slot size class is chosen from a sound upper bound (is_exact analyser), not a checkpoint-sampled high-water estimate that can under-count — restoring the T3.4.4 invariant that only the inexact fallback magnitude improves
-    - An imp whose true peak stack can exceed the Small slot is never placed in one; a test exercises the shallow-sample-then-deep-descent boundary under -DCSP_ANALYSE_STACKS on arm64
-    context: 'HIGH, confirmed by two-lens verification (2026-07-03). src/csp.cc:476: StackClass::Small is selected purely from profile_needed = high_water*1.5 + headroom, with no is_exact gate and no analyser call — an independent path that preempts the sound analyser. The high-water is a do_switch checkpoint sample, not a peak, so a helper that grows and unwinds between two channel ops is never sampled; a shallow instance''s sample then gates a deep instance''s Small allocation. Arena slots have only a 4 KB software guard (no PROT_NONE page on arm64), so a descent into the neighbouring slot silently corrupts an adjacent imp''s Imp control block and stack. The verifier confirmed this violates the repo''s own T3.4.4 acceptance criteria. Found by Fable-5 audit 2026-07 (docs/audit/fable-2026-07.md).'
-    origin: manual
-    discovered: 2026-07-03
   T31:
     name: Stack-analysis walker reads forwarded data pointers within bounds (no ASan over-read)
-    status: identified
+    status: achieved
     value: 0.0
     cost: 0.0
+    actual_cost: 3.0
     acceptance:
     - A full local sanitized build (make SANITIZE=address,undefined) on ARM64 macOS runs the whole suite — including test/stack_analysis_audit.test.cc — with no AddressSanitizer global-buffer-overflow in src/stack_analysis_arm64.cc.
     - The walker either bounds its forwarded-data-pointer read to the load width it actually decoded, OR the audit fixtures provide correctly-sized (8-byte) data slots for the 64-bit load the walker models, with a comment stating the contract.
@@ -1081,6 +1076,20 @@ targets:
     - T3.4.5
     origin: discovered during v0.20.0 release, session 2026-07-01
     discovered: 2026-07-01
+    achieved: 2026-07-05
+  T33:
+    name: csp sizes stack slots from a true high-water bound so a Small slot can never be chosen for an imp that overflows it
+    status: achieved
+    value: 8.0
+    cost: 5.0
+    actual_cost: 3.0
+    acceptance:
+    - The stack-slot size class is chosen from a sound upper bound (is_exact analyser), not a checkpoint-sampled high-water estimate that can under-count — restoring the T3.4.4 invariant that only the inexact fallback magnitude improves
+    - An imp whose true peak stack can exceed the Small slot is never placed in one; a test exercises the shallow-sample-then-deep-descent boundary under -DCSP_ANALYSE_STACKS on arm64
+    context: 'HIGH, confirmed by two-lens verification (2026-07-03). src/csp.cc:476: StackClass::Small is selected purely from profile_needed = high_water*1.5 + headroom, with no is_exact gate and no analyser call — an independent path that preempts the sound analyser. The high-water is a do_switch checkpoint sample, not a peak, so a helper that grows and unwinds between two channel ops is never sampled; a shallow instance''s sample then gates a deep instance''s Small allocation. Arena slots have only a 4 KB software guard (no PROT_NONE page on arm64), so a descent into the neighbouring slot silently corrupts an adjacent imp''s Imp control block and stack. The verifier confirmed this violates the repo''s own T3.4.4 acceptance criteria. Found by Fable-5 audit 2026-07 (docs/audit/fable-2026-07.md).'
+    origin: manual
+    discovered: 2026-07-03
+    achieved: 2026-07-04
   T4:
     name: API safety gaps are closed
     status: achieved

--- a/test/stack_analysis_audit.test.cc
+++ b/test/stack_analysis_audit.test.cc
@@ -27,6 +27,23 @@
 #include <atomic>
 #include <sstream>
 
+// 🎯T31: detect whether this TU is built under a sanitizer that instruments
+// memory accesses (ASan) or every load/store (TSan). Such builds inject
+// interceptor calls — `bl __asan_report_loadN`, `bl __tsan_readN` — into every
+// data-touching function. Those stubs live in __TEXT,__stubs, outside the
+// walker's __TEXT,__text bound, so the walker soundly widens each instrumented
+// candidate to budget (is_exact=false). Tightness is therefore not measurable
+// under instrumentation, though soundness (an over-approximation) still holds.
+#if defined(__has_feature)
+#  if __has_feature(address_sanitizer) || __has_feature(thread_sanitizer)
+#    define CSP_AUDIT_SANITIZED 1
+#  endif
+#endif
+#if !defined(CSP_AUDIT_SANITIZED) && \
+    (defined(__SANITIZE_ADDRESS__) || defined(__SANITIZE_THREAD__))
+#  define CSP_AUDIT_SANITIZED 1
+#endif
+
 namespace {
 
 // Portable "don't inline this" so each fixture keeps its own frame and the
@@ -188,8 +205,24 @@ void x1_entry(void* data) {
 
 // (d) 🎯T3.10 CONST forwarding: a discriminator that arrives in the callee's
 //     W0 and prunes a branch before any inner BL.
-struct const_data { int which; };
-const_data g_const{0};
+//
+// 🎯T31 fixture contract — the closure passed to analyze_stack_depth is
+// modelled as a pointer-width-or-larger object. The walker always dereferences
+// a forwarded/entry data pointer with a 64-bit load (a forwarded data
+// sub-pointer is a `void*`; see OP_CALL_DIRECT_WITH_DATA in
+// src/stack_analysis_arm64.cc). Under ASan the walker additionally follows the
+// compiler's shadow-check slow path, whose `bl __asan_report_loadN` forwards
+// the closure pointer itself — so even this fixture, whose logical payload is
+// a 4-byte discriminator, has its backing object read 8 bytes wide. Real
+// spawn() closures are always >= sizeof(void*); a bare 4-byte object is not a
+// valid closure. `which` must stay a 4-byte int at offset 0 so it materialises
+// as a CONST for branch pruning (widening it to 64 bits would make the load
+// look like a pointer field and defeat the pruning this case exists to test);
+// the trailing pad makes the object pointer-width so the modelled 64-bit read
+// stays in bounds. Without the pad, ASan trips a global-buffer-overflow one
+// byte past g_const.
+struct const_data { int which; int _pad; };
+const_data g_const{0, 0};
 static AUDIT_NOINLINE void const_small(void*) {
     volatile char buf[40];
     buf[0] = 1;
@@ -340,11 +373,16 @@ TEST_CASE("soundness-and-tightness-report") {
     // The instruction walker is ARM64-only; on other architectures
     // analyze_stack_depth is a conservative stub that always returns
     // is_exact=false, so tightness is not measurable there (every candidate
-    // reads "loose"). Soundness — gated above for every case — still holds,
-    // because an inexact estimate is vacuously sound. Enforce the tightness
-    // target only where the real walker runs.
-#if defined(__aarch64__)
+    // reads "loose"). Under a sanitizer (🎯T31) the walker widens every
+    // instrumented candidate for the same reason. Soundness — gated above for
+    // every case — still holds in both situations, because an inexact estimate
+    // is vacuously sound. Enforce the tightness target only where the real,
+    // uninstrumented walker runs.
+#if defined(__aarch64__) && !defined(CSP_AUDIT_SANITIZED)
     CHECK(candidate_tight >= 4);
+#elif defined(__aarch64__)
+    MESSAGE("tightness gate skipped — sanitizer instrumentation injects "
+            "interceptor calls the walker soundly widens on");
 #else
     MESSAGE("tightness gate skipped — the stack walker is ARM64-only");
 #endif


### PR DESCRIPTION
## 🎯T31 — Stack-analysis walker reads forwarded data pointers within bounds

Fixes the `global-buffer-overflow` a full local `make SANITIZE=address,undefined`
reports at `src/stack_analysis_arm64.cc:1699` (`analyze_stack_depth`), an 8-byte
read landing one byte past the 4-byte global `g_const` in
`test/stack_analysis_audit.test.cc`. Byte-identical to master/v0.19.0 — not
introduced by any recent change; masked on CI (layout-dependent) and absent
from the dist build (the audit test is excluded from the amalgamation).

### Root cause (confirmed via lldb)
The over-read originates at `stack_analysis_arm64.cc:1623` — the compact
`OP_CALL_DIRECT_WITH_DATA` "forward a data sub-pointer" opcode. Under ASan the
walker follows `const_entry`'s shadow-check slow path: `bl __asan_report_load4(x0)`,
where `x0` is the entry data pointer (`DATA_OFFSET(0)`). It forwards that
pointer as an 8-byte data sub-pointer and reads `*(void**)&g_const` — 8 bytes
from a bare 4-byte `int`.

This is an **ASan-instrumentation artifact, not a production bug**: no
shadow-check `bl` exists in a non-ASan build, the 8-byte read is correct for a
real closure, and the walker contractually models `data` as a pointer-width
closure. Real `spawn()` closures are always ≥ `sizeof(void*)`; the fixture
passed a 4-byte `int` as the "closure," violating that contract.

### Fix (acceptance option 2 — fix the fixture, not the walker)
- Pad `const_data` to pointer width with a documented contract comment, keeping
  `which` a 4-byte `int` at offset 0 so it still materialises as a CONST for
  branch pruning (widening the field would defeat the pruning this case tests).
- Guard the audit's hard tightness gate with `CSP_AUDIT_SANITIZED`: fixing the
  crash let the gate run under ASan for the first time, where it fails
  legitimately — sanitizer interceptor calls (`__asan_report_*`, `__tsan_*`)
  live in `__TEXT,__stubs` outside the walker's `__TEXT,__text` bound, so the
  walker soundly widens every instrumented candidate to budget and nothing
  reads "tight" (2/6). Tightness is not measurable under instrumentation;
  soundness (over-approximation) still holds 10/10. Mirrors the existing
  ARM64-only guard.

### Verification (ARM64 macOS)
- Full `make SANITIZE=address,undefined` suite: **739/739 clean**, no over-read.
- Normal build unchanged: `const_arg_prune` still `is_exact`/tight, **6/6 tight
  candidates**, `StackAnalysis` 18/18.
- Standing invariants (`make bullseye`) all green.

Also captures the T29 CI-watchdog design (and a stale-GDB-path finding) in that
target's context for its own follow-up PR; retires 🎯T31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)