### PR TITLE
Coin-flip third-pairing deadlock + stack-analysis ASan fix

### DIFF
--- a/STABILITY.md
+++ b/STABILITY.md
@@ -16,9 +16,9 @@ namespaces (`csp::internal`, `csp::detail`) are not part of the public API.
 
 | Symbol | Value | Stability |
 |--------|-------|-----------|
-| `CSP_VERSION` | `"0.12.0"` | Stable |
+| `CSP_VERSION` | `"0.22.0"` | Stable |
 | `CSP_VERSION_MAJOR` | `0` | Stable |
-| `CSP_VERSION_MINOR` | `12` | Stable |
+| `CSP_VERSION_MINOR` | `22` | Stable |
 | `CSP_VERSION_PATCH` | `0` | Stable |
 
 ### Core types

--- a/dist/csp.h
+++ b/dist/csp.h
@@ -7,9 +7,9 @@
 
 /* csp/csp.h */
 
-#define CSP_VERSION "0.21.0"
+#define CSP_VERSION "0.22.0"
 #define CSP_VERSION_MAJOR 0
-#define CSP_VERSION_MINOR 21
+#define CSP_VERSION_MINOR 22
 #define CSP_VERSION_PATCH 0
 
 

--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#define CSP_VERSION "0.21.0"
+#define CSP_VERSION "0.22.0"
 #define CSP_VERSION_MAJOR 0
-#define CSP_VERSION_MINOR 21
+#define CSP_VERSION_MINOR 22
 #define CSP_VERSION_PATCH 0
 
 #include <csp/internal/log.h>


### PR DESCRIPTION
## Fixed

- **Coin-flip third-pairing self-deadlock** that hung CI under dist-TSan: an imp alting over both ends of the same channel while holding its own endpoint copies could strand forever when peers paired elsewhere (#92).
- **ASan over-read in the stack-analysis audit fixture** (🎯T31) (#90).

## Changed

- CI hang watchdog: dist-TSan hangs now core-dump and self-backtrace for faster diagnosis (#91).
- Documented the self-holding-alt deadlock gotcha in `dist/AGENTS-CSP.md`.
- Bumped `CSP_VERSION` to 0.22.0; refreshed `STABILITY.md` version-macro table.
